### PR TITLE
import(reflect-metadata) doesn't actually import the types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,3 @@ typings/
 
 # Compiled output
 dist/
-*.d.ts

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,3 @@
-import("reflect-metadata");
-
 import {INJECTION_TOKEN_METADATA_KEY, getParamInfo} from "./reflection-helpers";
 import {InjectionToken, Provider} from "./providers";
 import {RegistrationOptions, constructor} from "./types";

--- a/src/reflect-metadata.d.ts
+++ b/src/reflect-metadata.d.ts
@@ -1,0 +1,1 @@
+import "reflect-metadata";


### PR DESCRIPTION
The change I made to `import("reflect-metadata");` didn't actually import the types and it was just a dynamic import. That method still works for commonjs but it will import the full reflect-metadata. I could only find 2 ways to get it to work:

1. Specify the types in tsconfig.json
2. Create a type declaration (ex: reflect-metadata.d.ts) that calls `import "reflect-metadata";`

This PR uses option 2 - let me know what you think.