### PR TITLE
@autoInjectable should throw a clear error if dependencies can't be resolved

### DIFF
--- a/src/__tests__/auto-injectable.test.ts
+++ b/src/__tests__/auto-injectable.test.ts
@@ -111,3 +111,13 @@ test("@autoInjectable classes resolve their @injectable dependencies", () => {
 
   expect(myFooBar.myBar!.myFoo instanceof Foo).toBeTruthy();
 });
+
+test("@autoInjectable throws a clear error if a dependency can't be resolved.", () => {
+  interface Bar { someval: string; }
+  @autoInjectable()
+  class Foo {
+    constructor(public myBar?: Bar) { }
+  }
+
+  expect(() => new Foo()).toThrow(/Cannot inject the dependency myBar of Foo constructor. TypeInfo/);
+});

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -42,7 +42,18 @@ export function autoInjectable(): (target: constructor<any>) => any {
 
     return class extends target {
       constructor(...args: any[]) {
-        super(...args.concat(paramInfo.slice(args.length).map(type => globalContainer.resolve(type))));
+        super(...args.concat(paramInfo.slice(args.length).map((type, index) => {
+          try {
+            return globalContainer.resolve(type);
+          } catch (e) {
+            const argIndex = index + args.length;
+
+            const [, params = null] = target.toString().match(/constructor\(([\w, ]+)\)/) || [];
+            const argName = params ? params.split(",")[argIndex] : `#${argIndex}`;
+
+            throw `Cannot inject the dependency ${argName} of ${target.name} constructor. ${e}`;
+          }
+        })));
       }
     };
   };


### PR DESCRIPTION
Currently, @autoInjectable class throws the following exceptions when a dependency isn't registered:
```
/www/ts-test/node_modules/tsyringe/dist/cjs/dependency-container.js:55
                throw `Attempted to resolve unregistered dependency token: ${token.toString()}`;
                ^
Attempted to resolve unregistered dependency token: new Function() as any
```

This PR adds information about exact class and attribute name:
```Cannot inject the dependency myBar of Foo constructor. TypeInfo not known for function Object() { [native code] }```