### PR TITLE
[feat] Scope lifestyle support

### DIFF
--- a/src/__tests__/scopes-container.test.ts
+++ b/src/__tests__/scopes-container.test.ts
@@ -1,0 +1,66 @@
+import {instance as globalContainer} from "../dependency-container";
+import scoped from "../decorators/scoped";
+import {injectable, singleton} from "../decorators";
+
+afterEach(() => {
+  globalContainer.reset();
+});
+
+test("create a new instance of requestScope'd service within a new requestScope", async () => {
+  @scoped()
+  class X {}
+
+  @injectable()
+  class B {
+    constructor(public x: X) {}
+  }
+
+  @injectable()
+  class C {
+    constructor(public x: X) {}
+  }
+
+  const b = globalContainer.resolve(B);
+  const cOuter = globalContainer.resolve(C);
+  expect(b.x).toBe(cOuter.x);
+
+  await globalContainer.enterScope(requestScope => {
+    const cInner = requestScope.resolve(C);
+    expect(b.x).not.toBe(cInner.x);
+  });
+});
+
+test("the requestScope'd service within a new requestScope is persisted for the duration of the scope", async () => {
+  @scoped()
+  class X {}
+
+  await globalContainer.enterScope(requestScope1 => {
+    const x1 = requestScope1.resolve(X);
+    const x2 = requestScope1.resolve(X);
+
+    expect(x1).toBeTruthy();
+    expect(x2).toBeTruthy();
+    expect(x1).toBe(x2);
+
+    requestScope1.enterScope(requestScope2 => {
+      const x3 = requestScope2.resolve(X);
+
+      expect(x3).toBeTruthy();
+      expect(x1).not.toBe(x3);
+    });
+  });
+});
+
+test("singletons are persisted between within a requestScope", async () => {
+  @singleton()
+  class Foo {}
+
+  const fooOuter = globalContainer.resolve(Foo);
+
+  expect(fooOuter).toBeTruthy();
+
+  await globalContainer.enterScope(requestScope => {
+    const fooInner = requestScope.resolve(Foo);
+    expect(fooOuter).toBe(fooInner);
+  });
+});

--- a/src/decorators/scoped.ts
+++ b/src/decorators/scoped.ts
@@ -1,0 +1,17 @@
+import constructor from "../types/constructor";
+import injectable from "./injectable";
+import {instance as globalContainer} from "../dependency-container";
+
+/**
+ * Class decorator factory that registers the class as a scoped service.
+ *
+ * @return {Function} The class decorator
+ */
+function scoped<T>(): (target: constructor<T>) => void {
+  return function(target: constructor<T>): void {
+    injectable()(target);
+    globalContainer.registerScoped(target);
+  };
+}
+
+export default scoped;

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -38,8 +38,10 @@ export default interface DependencyContainer {
     token: InjectionToken<T>,
     instance: T
   ): DependencyContainer;
+  registerScoped<T>(token: constructor<T>): DependencyContainer;
   resolve<T>(token: InjectionToken<T>): T;
   isRegistered<T>(token: InjectionToken<T>): boolean;
   reset(): void;
   createChildContainer(): DependencyContainer;
+  enterScope(scope: (container: DependencyContainer) => any): void;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export {default as constructor} from "./constructor";
 export {default as DependencyContainer} from "./dependency-container";
 export {default as Dictionary} from "./dictionary";
 export {default as RegistrationOptions} from "./registration-options";
+export {default as Lifestyle} from "./lifestyle";

--- a/src/types/lifestyle.ts
+++ b/src/types/lifestyle.ts
@@ -1,0 +1,6 @@
+enum Lifestyle {
+  TRANSIENT = "transient",
+  SINGLETON = "singleton",
+  SCOPED = "scoped"
+}
+export default Lifestyle;

--- a/src/types/registration-options.ts
+++ b/src/types/registration-options.ts
@@ -1,5 +1,8 @@
+import Lifestyle from "./lifestyle";
+
 type RegistrationOptions = {
-  singleton: boolean;
+  lifestyle?: Lifestyle;
+  singleton?: boolean;
 };
 
 export default RegistrationOptions;


### PR DESCRIPTION
Added a 'scoping' support. A '@scoped()' service is a service that is created and persisted for the duration of a scope. 

This is purely a proof-of-concept, something that I have thrown together for my own use-case. 

I welcome all comments/feedback.