### PR TITLE
Allow multiple types bound to a single token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# VS code folder
+.vscode
+
 # Runtime data
 pids
 *.pid

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
-}

--- a/src/__tests__/auto-injectable.test.ts
+++ b/src/__tests__/auto-injectable.test.ts
@@ -141,3 +141,15 @@ test("@autoInjectable works with @singleton", () => {
   expect(instance1).toBe(instance2);
   expect(instance1.bar).toBe(instance2.bar);
 });
+
+test("@autoInjectable throws for array dependency", () => {
+  @injectable()
+  class Bar {}
+
+  @autoInjectable()
+  class Foo {
+    constructor(public bar?: Bar[]) {}
+  }
+
+  expect(() => new Foo()).toThrow();
+});

--- a/src/__tests__/auto-injectable.test.ts
+++ b/src/__tests__/auto-injectable.test.ts
@@ -1,5 +1,6 @@
 import {autoInjectable, injectable, singleton} from "../decorators";
 import {instance as globalContainer} from "../dependency-container";
+import injectAll from "../decorators/inject-all";
 
 afterEach(() => {
   globalContainer.reset();
@@ -142,14 +143,39 @@ test("@autoInjectable works with @singleton", () => {
   expect(instance1.bar).toBe(instance2.bar);
 });
 
-test("@autoInjectable throws for array dependency", () => {
+test("@autoInjectable resolves multiple registered dependencies", () => {
+  interface Bar {
+    str: string;
+  }
+
   @injectable()
-  class Bar {}
+  class FooBar implements Bar {
+    str: string = "";
+  }
+
+  globalContainer.register<Bar>("Bar", {useClass: FooBar});
 
   @autoInjectable()
   class Foo {
-    constructor(public bar?: Bar[]) {}
+    constructor(@injectAll("Bar") public bar?: Bar[]) {}
   }
 
-  expect(() => new Foo()).toThrow();
+  const foo = new Foo();
+  expect(Array.isArray(foo.bar)).toBeTruthy();
+  expect(foo.bar!.length).toBe(1);
+  expect(foo.bar![0]).toBeInstanceOf(FooBar);
+});
+
+test("@autoInjectable resolves multiple transient dependencies", () => {
+  class Foo {}
+
+  @autoInjectable()
+  class Bar {
+    constructor(@injectAll(Foo) public foo?: Foo[]) {}
+  }
+
+  const bar = new Bar();
+  expect(Array.isArray(bar.foo)).toBeTruthy();
+  expect(bar.foo!.length).toBe(1);
+  expect(bar.foo![0]).toBeInstanceOf(Foo);
 });

--- a/src/__tests__/child-container.test.ts
+++ b/src/__tests__/child-container.test.ts
@@ -41,7 +41,7 @@ test("child container resolves all even when parent doesn't have registration", 
 
   expect(Array.isArray(myFoo)).toBeTruthy();
   expect(myFoo.length).toBe(1);
-  expect(myFoo[0] instanceof Foo).toBeTruthy
+  expect(myFoo[0] instanceof Foo).toBeTruthy();
 });
 
 test("child container resolves all using parent's registration when child container doesn't have registration", () => {

--- a/src/__tests__/child-container.test.ts
+++ b/src/__tests__/child-container.test.ts
@@ -2,6 +2,10 @@
 
 import {instance as globalContainer} from "../dependency-container";
 
+afterEach(() => {
+  globalContainer.reset();
+});
+
 test("child container resolves even when parent doesn't have registration", () => {
   interface IFoo {}
   class Foo implements IFoo {}
@@ -14,7 +18,7 @@ test("child container resolves even when parent doesn't have registration", () =
   expect(myFoo instanceof Foo).toBeTruthy();
 });
 
-test("child container resolves using parents' registration when child container doesn't have registration", () => {
+test("child container resolves using parent's registration when child container doesn't have registration", () => {
   interface IFoo {}
   class Foo implements IFoo {}
 
@@ -24,4 +28,32 @@ test("child container resolves using parents' registration when child container 
   const myFoo = container.resolve<Foo>("IFoo");
 
   expect(myFoo instanceof Foo).toBeTruthy();
+});
+
+test("child container resolves all even when parent doesn't have registration", () => {
+  interface IFoo {}
+  class Foo implements IFoo {}
+
+  const container = globalContainer.createChildContainer();
+  container.register("IFoo", {useClass: Foo});
+
+  const myFoo = container.resolveAll<IFoo>("IFoo");
+
+  expect(Array.isArray(myFoo)).toBeTruthy();
+  expect(myFoo.length).toBe(1);
+  expect(myFoo[0] instanceof Foo).toBeTruthy
+});
+
+test("child container resolves all using parent's registration when child container doesn't have registration", () => {
+  interface IFoo {}
+  class Foo implements IFoo {}
+
+  globalContainer.register("IFoo", {useClass: Foo});
+  const container = globalContainer.createChildContainer();
+
+  const myFoo = container.resolveAll<IFoo>("IFoo");
+
+  expect(Array.isArray(myFoo)).toBeTruthy();
+  expect(myFoo.length).toBe(1);
+  expect(myFoo[0] instanceof Foo).toBeTruthy();
 });

--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -169,6 +169,30 @@ test("resolves anonymous classes separately", () => {
   expect(globalContainer.resolve(ctor2) instanceof ctor2).toBeTruthy();
 });
 
+// --- resolveAll() ---
+
+test("resolves an array of transient instances bound to a single interface", () => {
+  interface FooInterface {
+    bar: string;
+  }
+
+  class FooOne implements FooInterface {
+    public bar: string = "foo1";
+  }
+
+  class FooTwo implements FooInterface {
+    public bar: string = "foo2";
+  }
+
+  globalContainer.register<FooInterface>("FooInterface", {useClass: FooOne});
+  globalContainer.register<FooInterface>("FooInterface", {useClass: FooTwo});
+
+  const fooArray = globalContainer.resolveAll<FooInterface>("FooInterface");
+  expect(Array.isArray(fooArray)).toBeTruthy();
+  expect(fooArray[0]).toBeInstanceOf(FooOne);
+  expect(fooArray[1]).toBeInstanceOf(FooTwo);
+});
+
 // --- isRegistered() ---
 
 test("returns true for a registered singleton class", () => {

--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -199,6 +199,12 @@ test("resolves anonymous classes separately", () => {
 
 // --- resolveAll() ---
 
+test("fails to resolveAll unregistered dependency by name", () => {
+  expect(() => {
+    globalContainer.resolveAll("NotRegistered");
+  }).toThrow();
+});
+
 test("resolves an array of transient instances bound to a single interface", () => {
   interface FooInterface {
     bar: string;
@@ -219,6 +225,19 @@ test("resolves an array of transient instances bound to a single interface", () 
   expect(Array.isArray(fooArray)).toBeTruthy();
   expect(fooArray[0]).toBeInstanceOf(FooOne);
   expect(fooArray[1]).toBeInstanceOf(FooTwo);
+});
+
+test("resolves all transient instances when not registered", () => {
+  class Foo {}
+
+  const foo1 = globalContainer.resolveAll<Foo>(Foo);
+  const foo2 = globalContainer.resolveAll<Foo>(Foo);
+
+  expect(Array.isArray(foo1)).toBeTruthy();
+  expect(Array.isArray(foo2)).toBeTruthy();
+  expect(foo1[0]).toBeInstanceOf(Foo);
+  expect(foo2[0]).toBeInstanceOf(Foo);
+  expect(foo1[0]).not.toBe(foo2[0]);
 });
 
 // --- isRegistered() ---

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -1,0 +1,64 @@
+import Registry from "../registry";
+import {Registration} from "../dependency-container";
+
+let registry: Registry;
+beforeEach(() => {
+  registry = new Registry();
+});
+
+test("getAll returns all registrations of a given key", () => {
+  const registration1: Registration = {
+    options: {singleton: false},
+    provider: {useValue: "provider"}
+  };
+  const registration2: Registration = {
+    options: {singleton: false},
+    provider: {useValue: "provider"}
+  };
+
+  registry.set("Foo", registration1);
+  registry.set("Foo", registration2);
+
+  expect(registry.has("Foo")).toBeTruthy();
+
+  const all = registry.getAll("Foo");
+  expect(Array.isArray(all)).toBeTruthy();
+  expect(all.length).toBe(2);
+  expect(all[0]).toStrictEqual(registration1);
+  expect(all[1]).toStrictEqual(registration2);
+});
+
+test("get returns the last registration", () => {
+  const registration1: Registration = {
+    options: {singleton: false},
+    provider: {useValue: "provider"}
+  };
+  const registration2: Registration = {
+    options: {singleton: false},
+    provider: {useValue: "provider"}
+  };
+
+  registry.set("Bar", registration1);
+  registry.set("Bar", registration2);
+
+  expect(registry.has("Bar")).toBeTruthy();
+  expect(registry.get("Bar")).toStrictEqual(registration2);
+});
+
+test("get returns null when there is no registration", () => {
+  expect(registry.has("FooBar")).toBeFalsy();
+  expect(registry.get("FooBar")).toBeNull();
+});
+
+test("clear removes all registrations", () => {
+  const registration: Registration = {
+    options: {singleton: false},
+    provider: {useValue: "provider"}
+  };
+
+  registry.set("Foo", registration);
+  expect(registry.has("Foo")).toBeTruthy();
+
+  registry.clear();
+  expect(registry.has("Foo")).toBeFalsy();
+});

--- a/src/decorators/auto-injectable.ts
+++ b/src/decorators/auto-injectable.ts
@@ -1,6 +1,7 @@
 import constructor from "../types/constructor";
 import {getParamInfo} from "../reflection-helpers";
 import {instance as globalContainer} from "../dependency-container";
+import {isTokenDescriptor} from "../providers/injection-token";
 
 /**
  * Class decorator factory that replaces the decorated class' constructor with
@@ -20,6 +21,11 @@ function autoInjectable(): (target: constructor<any>) => any {
           ...args.concat(
             paramInfo.slice(args.length).map((type, index) => {
               try {
+                if (isTokenDescriptor(type)) {
+                  return type.multiple
+                    ? globalContainer.resolveAll(type.token)
+                    : globalContainer.resolve(type.token);
+                }
                 return globalContainer.resolve(type);
               } catch (e) {
                 const argIndex = index + args.length;

--- a/src/decorators/inject-all.ts
+++ b/src/decorators/inject-all.ts
@@ -1,0 +1,28 @@
+import {INJECTION_TOKEN_METADATA_KEY} from "../reflection-helpers";
+import InjectionToken from "../providers/injection-token";
+
+/**
+ * Parameter decorator factory that allows for interface information to be stored in the constructor's metadata
+ *
+ * @return {Function} The parameter decorator
+ */
+function injectAll(
+  token: InjectionToken<any>
+): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+  return function(
+    target: any,
+    _propertyKey: string | symbol,
+    parameterIndex: number
+  ): any {
+    const injectionTokens =
+      Reflect.getOwnMetadata(INJECTION_TOKEN_METADATA_KEY, target) || {};
+    injectionTokens[parameterIndex] = {token, multiple: true};
+    Reflect.defineMetadata(
+      INJECTION_TOKEN_METADATA_KEY,
+      injectionTokens,
+      target
+    );
+  };
+}
+
+export default injectAll;

--- a/src/decorators/inject-all.ts
+++ b/src/decorators/inject-all.ts
@@ -1,5 +1,5 @@
-import {INJECTION_TOKEN_METADATA_KEY} from "../reflection-helpers";
-import InjectionToken from "../providers/injection-token";
+import {defineInjectionTokenMetadata} from "../reflection-helpers";
+import InjectionToken, {TokenDescriptor} from "../providers/injection-token";
 
 /**
  * Parameter decorator factory that allows for interface information to be stored in the constructor's metadata
@@ -9,20 +9,8 @@ import InjectionToken from "../providers/injection-token";
 function injectAll(
   token: InjectionToken<any>
 ): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
-  return function(
-    target: any,
-    _propertyKey: string | symbol,
-    parameterIndex: number
-  ): any {
-    const injectionTokens =
-      Reflect.getOwnMetadata(INJECTION_TOKEN_METADATA_KEY, target) || {};
-    injectionTokens[parameterIndex] = {token, multiple: true};
-    Reflect.defineMetadata(
-      INJECTION_TOKEN_METADATA_KEY,
-      injectionTokens,
-      target
-    );
-  };
+  const data: TokenDescriptor = {token, multiple: true};
+  return defineInjectionTokenMetadata(data);
 }
 
 export default injectAll;

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -1,4 +1,4 @@
-import {INJECTION_TOKEN_METADATA_KEY} from "../reflection-helpers";
+import {defineInjectionTokenMetadata} from "../reflection-helpers";
 import InjectionToken from "../providers/injection-token";
 
 /**
@@ -9,20 +9,7 @@ import InjectionToken from "../providers/injection-token";
 function inject(
   token: InjectionToken<any>
 ): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
-  return function(
-    target: any,
-    _propertyKey: string | symbol,
-    parameterIndex: number
-  ): any {
-    const injectionTokens =
-      Reflect.getOwnMetadata(INJECTION_TOKEN_METADATA_KEY, target) || {};
-    injectionTokens[parameterIndex] = token;
-    Reflect.defineMetadata(
-      INJECTION_TOKEN_METADATA_KEY,
-      injectionTokens,
-      target
-    );
-  };
+  return defineInjectionTokenMetadata(token);
 }
 
 export default inject;

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -155,34 +155,14 @@ class InternalDependencyContainer implements DependencyContainer {
     }
 
     if (registration) {
-      if (isValueProvider(registration.provider)) {
-        return registration.provider.useValue;
-      } else if (isTokenProvider(registration.provider)) {
-        return registration.options.singleton
-          ? registration.instance ||
-              (registration.instance = this.resolve(
-                registration.provider.useToken
-              ))
-          : this.resolve(registration.provider.useToken);
-      } else if (isClassProvider(registration.provider)) {
-        return registration.options.singleton
-          ? registration.instance ||
-              (registration.instance = this.construct(
-                registration.provider.useClass
-              ))
-          : this.construct(registration.provider.useClass);
-      } else if (isFactoryProvider(registration.provider)) {
-        return registration.provider.useFactory(this);
-      } else {
-        return this.construct(registration.provider);
-      }
+      return this.resolveRegistration(registration);
     }
 
     // No registration for this token, but since it's a constructor, return an instance
     return this.construct(<constructor<T>>token);
   }
 
-  private resolveToken<T>(registration: Registration): T {
+  private resolveRegistration<T>(registration: Registration): T {
     if (isValueProvider(registration.provider)) {
       return registration.provider.useValue;
     } else if (isTokenProvider(registration.provider)) {
@@ -214,7 +194,7 @@ class InternalDependencyContainer implements DependencyContainer {
     }
 
     if (registration) {
-      return registration.map(item => this.resolveToken<T>(item));
+      return registration.map(item => this.resolveRegistration<T>(item));
     }
 
     // No registration for this token, but since it's a constructor, return an instance

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -187,7 +187,7 @@ class InternalDependencyContainer implements DependencyContainer {
   }
 
   public resolveAll<T>(token: InjectionToken<T>): T[] {
-    const registration = this.getAllRegistration(token);
+    const registration = this.getAllRegistrations(token);
 
     if (!registration && isNormalToken(token)) {
       throw `Attempted to resolve unregistered dependency token: ${token.toString()}`;
@@ -233,7 +233,7 @@ class InternalDependencyContainer implements DependencyContainer {
     return null;
   }
 
-  private getAllRegistration<T>(
+  private getAllRegistrations<T>(
     token: InjectionToken<T>
   ): Registration[] | null {
     if (this.isRegistered(token)) {
@@ -241,7 +241,7 @@ class InternalDependencyContainer implements DependencyContainer {
     }
 
     if (this.parent) {
-      return this.parent.getAllRegistration(token);
+      return this.parent.getAllRegistrations(token);
     }
 
     return null;

--- a/src/providers/injection-token.ts
+++ b/src/providers/injection-token.ts
@@ -8,4 +8,15 @@ export function isNormalToken(
   return typeof token === "string" || typeof token === "symbol";
 }
 
+export function isTokenDescriptor(
+  descriptor: any
+): descriptor is TokenDescriptor {
+  return "token" in descriptor && "multiple" in descriptor;
+}
+
+export interface TokenDescriptor {
+  token: InjectionToken<any>;
+  multiple: boolean;
+}
+
 export default InjectionToken;

--- a/src/providers/injection-token.ts
+++ b/src/providers/injection-token.ts
@@ -11,7 +11,11 @@ export function isNormalToken(
 export function isTokenDescriptor(
   descriptor: any
 ): descriptor is TokenDescriptor {
-  return "token" in descriptor && "multiple" in descriptor;
+  return (
+    typeof descriptor === "object" &&
+    "token" in descriptor &&
+    "multiple" in descriptor
+  );
 }
 
 export interface TokenDescriptor {

--- a/src/reflection-helpers.ts
+++ b/src/reflection-helpers.ts
@@ -9,7 +9,12 @@ export function getParamInfo(target: constructor<any>): any[] {
   const injectionTokens: Dictionary<InjectionToken<any>> =
     Reflect.getOwnMetadata(INJECTION_TOKEN_METADATA_KEY, target) || {};
   Object.keys(injectionTokens).forEach(key => {
-    params[+key] = injectionTokens[key];
+    // TODO this propably should be moved to a decorator
+    const type = params[+key];
+    params[+key] = {
+      token: injectionTokens[key],
+      multiple: type === Array
+    };
   });
 
   return params;

--- a/src/reflection-helpers.ts
+++ b/src/reflection-helpers.ts
@@ -14,3 +14,22 @@ export function getParamInfo(target: constructor<any>): any[] {
 
   return params;
 }
+
+export function defineInjectionTokenMetadata(
+  data: any
+): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+  return function(
+    target: any,
+    _propertyKey: string | symbol,
+    parameterIndex: number
+  ): any {
+    const injectionTokens =
+      Reflect.getOwnMetadata(INJECTION_TOKEN_METADATA_KEY, target) || {};
+    injectionTokens[parameterIndex] = data;
+    Reflect.defineMetadata(
+      INJECTION_TOKEN_METADATA_KEY,
+      injectionTokens,
+      target
+    );
+  };
+}

--- a/src/reflection-helpers.ts
+++ b/src/reflection-helpers.ts
@@ -9,12 +9,7 @@ export function getParamInfo(target: constructor<any>): any[] {
   const injectionTokens: Dictionary<InjectionToken<any>> =
     Reflect.getOwnMetadata(INJECTION_TOKEN_METADATA_KEY, target) || {};
   Object.keys(injectionTokens).forEach(key => {
-    // TODO this propably should be moved to a decorator
-    const type = params[+key];
-    params[+key] = {
-      token: injectionTokens[key],
-      multiple: type === Array
-    };
+    params[+key] = injectionTokens[key];
   });
 
   return params;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,37 @@
+import {InjectionToken} from ".";
+import {Registration} from "./dependency-container";
+
+export default class Registry {
+  protected _registryMap = new Map<InjectionToken<any>, Registration[]>();
+
+  public getAll(key: InjectionToken<any>): Registration[] {
+    this.ensure(key);
+    return this._registryMap.get(key)!;
+  }
+
+  public get(key: InjectionToken<any>): Registration | null {
+    this.ensure(key);
+    const value = this._registryMap.get(key)!;
+    return value[value.length - 1] || null;
+  }
+
+  public set(key: InjectionToken<any>, value: Registration): void {
+    this.ensure(key);
+    this._registryMap.get(key)!.push(value);
+  }
+
+  public has(key: InjectionToken<any>): boolean {
+    this.ensure(key);
+    return this._registryMap.get(key)!.length > 0;
+  }
+
+  public clear(): void {
+    this._registryMap.clear();
+  }
+
+  private ensure(key: InjectionToken<any>): void {
+    if (!this._registryMap.has(key)) {
+      this._registryMap.set(key, []);
+    }
+  }
+}

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -39,6 +39,7 @@ export default interface DependencyContainer {
     instance: T
   ): DependencyContainer;
   resolve<T>(token: InjectionToken<T>): T;
+  resolveAll<T>(token: InjectionToken<T>): T[];
   isRegistered<T>(token: InjectionToken<T>): boolean;
   reset(): void;
   createChildContainer(): DependencyContainer;


### PR DESCRIPTION
This is the implementation for the feature proposed on #39.

### Changes
+ Custom `Registry`: This new implementation allows multiple values to be registered within a single `InjectionToken`;
+ Add method `resolveAll()` to the interface `DependencyContainer`: This method behaves like the `resolve()` method, but returns an array with all dependencies bound to the given token instead;
+ Add decorator `@injectAll`: This decorator allows the injection of multiple dependencies bound to a given token;
+ Update `@autoInjectable` decorator to allow injection of multiple dependencies.

### Limitations
+ Due to the limitations of `reflect-metadata`, the decorator `@autoInjectable` can't resolve multiple dependencies if the parameter is not annotated with the `@injectAll` decorator.

### Compatibility 
+ Some test cases were added to ensure bc, since tsyringe allows registration of explicit array dependencies. e.g:

```ts
  class Bar {}
  const value = [new Bar()];
  globalContainer.register<Bar[]>("BarArray", {useValue: value});
  const barArray = globalContainer.resolve<Bar[]>("BarArray");
  expect(value === barArray).toBeTruthy();
```

