### PR TITLE
Scoped lifetime

### DIFF
--- a/src/__tests__/child-container.test.ts
+++ b/src/__tests__/child-container.test.ts
@@ -57,3 +57,14 @@ test("child container resolves all using parent's registration when child contai
   expect(myFoo.length).toBe(1);
   expect(myFoo[0] instanceof Foo).toBeTruthy();
 });
+
+test("isRegistered check parent containers recursively", () => {
+  class A {}
+
+  globalContainer.registerType(A, A);
+  const child = globalContainer.createChildContainer();
+
+  expect(globalContainer.isRegistered(A)).toBeTruthy();
+  expect(child.isRegistered(A)).toBeFalsy();
+  expect(child.isRegistered(A, true)).toBeTruthy();
+});

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -50,6 +50,21 @@ test("get returns null when there is no registration", () => {
   expect(registry.get("FooBar")).toBeNull();
 });
 
+test("setAll replaces everything with new value", () => {
+  const registration: Registration = {
+    options: {singleton: false},
+    provider: {useValue: "provider"}
+  };
+
+  expect(registry.has("Foo")).toBeFalsy();
+
+  registry.set("Foo", registration);
+  const fooArray = registry.getAll("Foo");
+  registry.setAll("Foo", [registration]);
+
+  expect(fooArray === registry.getAll("Foo")).toBeFalsy();
+});
+
 test("clear removes all registrations", () => {
   const registration: Registration = {
     options: {singleton: false},

--- a/src/__tests__/scoped-container.test.ts
+++ b/src/__tests__/scoped-container.test.ts
@@ -72,6 +72,27 @@ test("should not create a new instance of requested singleton service", () => {
   expect(bar1 === bar2).toBeTruthy();
 });
 
+test("allows multiple scope levels", () => {
+  class Bar {}
+
+  globalContainer.registerScoped(Bar, Bar);
+  const bar = globalContainer.resolve(Bar);
+
+  const scope1 = globalContainer.createScope();
+  const bar1 = scope1.resolve(Bar);
+
+  const scope2 = globalContainer.createScope();
+  const bar2 = scope2.resolve(Bar);
+
+  expect(bar === bar1).toBeFalsy();
+  expect(bar === bar2).toBeFalsy();
+  expect(bar1 === bar2).toBeFalsy();
+
+  expect(bar === globalContainer.resolve(Bar)).toBeFalsy();
+  expect(bar1 === scope1.resolve(Bar)).toBeTruthy();
+  expect(bar2 === scope2.resolve(Bar)).toBeTruthy();
+});
+
 test("@scoped decorator registers class as scoped", () => {
   @scoped()
   class Foo {}

--- a/src/__tests__/scoped-container.test.ts
+++ b/src/__tests__/scoped-container.test.ts
@@ -81,7 +81,7 @@ test("allows multiple scope levels", () => {
   const scope1 = globalContainer.createScope();
   const bar1 = scope1.resolve(Bar);
 
-  const scope2 = globalContainer.createScope();
+  const scope2 = scope1.createScope();
   const bar2 = scope2.resolve(Bar);
 
   expect(bar === bar1).toBeFalsy();

--- a/src/__tests__/scoped-container.test.ts
+++ b/src/__tests__/scoped-container.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/interface-name-prefix */
+
+import {instance as globalContainer} from "../dependency-container";
+import {Lifetime} from "../types";
+
+beforeEach(() => {
+  globalContainer.reset();
+});
+
+test("creates a new instance of requested service within a scope using class provider", () => {
+  class Foo {}
+
+  globalContainer.register(Foo, {useClass: Foo}, {lifetime: Lifetime.SCOPED});
+
+  const foo1 = globalContainer.resolve(Foo);
+
+  expect(foo1).toBeInstanceOf(Foo);
+
+  const scope = globalContainer.createScope();
+  const foo2 = scope.resolve(Foo);
+  const foo3 = scope.resolve(Foo);
+
+  expect(foo2).toBeInstanceOf(Foo);
+  expect(foo3).toBeInstanceOf(Foo);
+  expect(foo1 === foo2).toBeFalsy();
+  expect(foo2 === foo3).toBeTruthy();
+});
+
+test("creates a new instance of requested service within a scope using token provider", () => {
+  interface IBar {
+    void: string;
+  }
+  class Foo implements IBar {
+    void: string = "";
+  }
+
+  globalContainer.register("IBar", {useClass: Foo});
+  globalContainer.register(
+    Foo,
+    {useToken: "IBar"},
+    {lifetime: Lifetime.SCOPED}
+  );
+
+  const foo1 = globalContainer.resolve(Foo);
+
+  expect(foo1).toBeInstanceOf(Foo);
+
+  const scope = globalContainer.createScope();
+  const foo2 = scope.resolve(Foo);
+  const foo3 = scope.resolve(Foo);
+
+  expect(foo2).toBeInstanceOf(Foo);
+  expect(foo3).toBeInstanceOf(Foo);
+  expect(foo1 === foo2).toBeFalsy();
+  expect(foo2 === foo3).toBeTruthy();
+});
+
+test("should not create a new instance of requested singleton service", () => {
+  class Bar {}
+
+  globalContainer.registerSingleton(Bar, Bar);
+
+  const bar1 = globalContainer.resolve(Bar);
+
+  expect(bar1).toBeInstanceOf(Bar);
+
+  const scope = globalContainer.createScope();
+  const bar2 = scope.resolve(Bar);
+
+  expect(bar2).toBeInstanceOf(Bar);
+  expect(bar1 === bar2).toBeTruthy();
+});

--- a/src/__tests__/scoped-container.test.ts
+++ b/src/__tests__/scoped-container.test.ts
@@ -128,3 +128,38 @@ test("@scoped decorator registers class as scoped using custom token", () => {
   expect(foo1 === foo2).toBeFalsy();
   expect(foo2 === foo3).toBeTruthy();
 });
+
+test("resolve all resolves scoped dependencies properly", () => {
+  interface Foo {
+    test: string;
+  }
+
+  class FooBar implements Foo {
+    test: string = "bar";
+  }
+
+  class FooQux implements Foo {
+    test: string = "qux";
+  }
+
+  globalContainer.registerSingleton<Foo>("Foo", FooBar);
+  globalContainer.registerScoped<Foo>("Foo", FooQux);
+  const foo1 = globalContainer.resolveAll<Foo>("Foo");
+  const foo2 = globalContainer.resolveAll<Foo>("Foo");
+
+  expect(foo1[0] === foo2[0]).toBeTruthy();
+  expect(foo1[1] === foo2[1]).toBeFalsy();
+
+  const scope = globalContainer.createScope();
+  const foo3 = scope.resolveAll<Foo>("Foo");
+  const foo4 = scope.resolveAll<Foo>("Foo");
+
+  expect(foo3[0] === foo4[0]).toBeTruthy();
+  expect(foo3[1] === foo4[1]).toBeTruthy();
+
+  expect(foo3[0] === foo1[0]).toBeTruthy();
+  expect(foo4[0] === foo2[0]).toBeTruthy();
+
+  expect(foo3[1] === foo1[1]).toBeFalsy();
+  expect(foo4[1] === foo2[1]).toBeFalsy();
+});

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -4,3 +4,4 @@ export {default as injectable} from "./injectable";
 export {default as registry} from "./registry";
 export {default as singleton} from "./singleton";
 export {default as injectAll} from "./inject-all";
+export {default as scoped} from "./scoped";

--- a/src/decorators/scoped.ts
+++ b/src/decorators/scoped.ts
@@ -1,0 +1,21 @@
+import constructor from "../types/constructor";
+import injectable from "./injectable";
+import {instance as globalContainer} from "../dependency-container";
+import {InjectionToken} from "../providers";
+
+/**
+ * Class decorator factory that registers the class as a scoped dependency within
+ * the global container.
+ *
+ * @return {Function} The class decorator
+ */
+function scoped<T>(
+  token?: InjectionToken<any>
+): (target: constructor<T>) => void {
+  return function(target: constructor<T>): void {
+    injectable()(target);
+    globalContainer.registerScoped(token || target, target);
+  };
+}
+
+export default scoped;

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -276,7 +276,7 @@ class InternalDependencyContainer implements DependencyContainer {
       return reset;
     }
 
-    return null;
+    return registered || null;
   }
 
   private resetInstance(registered: Registration<any>): Registration<any> {

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -248,7 +248,7 @@ class InternalDependencyContainer implements DependencyContainer {
 
     const registered = this.parent && this.parent.getRegistration(token);
     if (registered && registered.options.lifetime === Lifetime.SCOPED) {
-      const reset = {...registered, instance: undefined};
+      const reset = this.resetInstance(registered);
       this._registry.set(token, reset);
       return reset;
     }

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -73,19 +73,30 @@ class InternalDependencyContainer implements DependencyContainer {
     return this;
   }
 
+  private registerTokenOrClass<T>(
+    from: InjectionToken<T>,
+    to: InjectionToken<T>,
+    options: RegistrationOptions = {lifetime: Lifetime.TRANSIENT}
+  ): InternalDependencyContainer {
+    if (isNormalToken(to)) {
+      return this.register(from, {useToken: to}, options);
+    }
+
+    return this.register(from, {useClass: to}, options);
+  }
+
   public registerType<T>(
     from: InjectionToken<T>,
     to: InjectionToken<T>
   ): InternalDependencyContainer {
-    if (isNormalToken(to)) {
-      return this.register(from, {
-        useToken: to
-      });
-    }
+    return this.registerTokenOrClass(from, to);
+  }
 
-    return this.register(from, {
-      useClass: to
-    });
+  public registerScoped<T>(
+    from: InjectionToken<T>,
+    to: InjectionToken<T>
+  ): InternalDependencyContainer {
+    return this.registerTokenOrClass(from, to, {lifetime: Lifetime.SCOPED});
   }
 
   public registerInstance<T>(
@@ -113,17 +124,13 @@ class InternalDependencyContainer implements DependencyContainer {
       if (isNormalToken(to)) {
         return this.register(
           from,
-          {
-            useToken: to
-          },
+          {useToken: to},
           {lifetime: Lifetime.SINGLETON}
         );
       } else if (to) {
         return this.register(
           from,
-          {
-            useClass: to
-          },
+          {useClass: to},
           {lifetime: Lifetime.SINGLETON}
         );
       }
@@ -136,13 +143,7 @@ class InternalDependencyContainer implements DependencyContainer {
       useClass = to;
     }
 
-    return this.register(
-      from,
-      {
-        useClass
-      },
-      {lifetime: Lifetime.SINGLETON}
-    );
+    return this.register(from, {useClass}, {lifetime: Lifetime.SINGLETON});
   }
 
   /**

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -27,11 +27,12 @@ export const typeInfo = new Map<constructor<any>, any[]>();
 /** Dependency Container */
 class InternalDependencyContainer implements DependencyContainer {
   protected _registry = new Registry();
+  /**
+   * Wether this container is within a scope
+   */
+  public readonly scoped: boolean = false;
 
-  public constructor(
-    protected parent?: InternalDependencyContainer,
-    protected scoped: boolean = false
-  ) {}
+  public constructor(protected parent?: InternalDependencyContainer) {}
 
   /**
    * Register a dependency provider.
@@ -238,7 +239,8 @@ class InternalDependencyContainer implements DependencyContainer {
   }
 
   public createScope(): DependencyContainer {
-    return new InternalDependencyContainer(this, true);
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return new ScopedInternalDependencyContainer(this);
   }
 
   private getRegistration<T>(token: InjectionToken<T>): Registration | null {
@@ -303,6 +305,14 @@ class InternalDependencyContainer implements DependencyContainer {
 
     return new ctor(...params);
   }
+}
+
+/** scoped dependency container */
+class ScopedInternalDependencyContainer extends InternalDependencyContainer {
+  /**
+   * @inheritdoc
+   */
+  public readonly scoped: boolean = true;
 }
 
 export const instance: DependencyContainer = new InternalDependencyContainer();

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -223,8 +223,16 @@ class InternalDependencyContainer implements DependencyContainer {
    *
    * @return {boolean}
    */
-  public isRegistered<T>(token: InjectionToken<T>): boolean {
-    return this._registry.has(token);
+  public isRegistered<T>(
+    token: InjectionToken<T>,
+    recursive: boolean = false
+  ): boolean {
+    return (
+      this._registry.has(token) ||
+      (recursive &&
+        (this.parent || false) &&
+        this.parent.isRegistered(token, true))
+    );
   }
 
   /**

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -20,6 +20,10 @@ export default class Registry {
     this._registryMap.get(key)!.push(value);
   }
 
+  public setAll(key: InjectionToken<any>, value: Registration[]): void {
+    this._registryMap.set(key, value);
+  }
+
   public has(key: InjectionToken<any>): boolean {
     this.ensure(key);
     return this._registryMap.get(key)!.length > 0;

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -38,6 +38,10 @@ export default interface DependencyContainer {
     token: InjectionToken<T>,
     instance: T
   ): DependencyContainer;
+  registerScoped<T>(
+    from: InjectionToken<T>,
+    to: InjectionToken<T>
+  ): DependencyContainer;
   resolve<T>(token: InjectionToken<T>): T;
   resolveAll<T>(token: InjectionToken<T>): T[];
   isRegistered<T>(token: InjectionToken<T>): boolean;

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -43,4 +43,5 @@ export default interface DependencyContainer {
   isRegistered<T>(token: InjectionToken<T>): boolean;
   reset(): void;
   createChildContainer(): DependencyContainer;
+  createScope(): DependencyContainer;
 }

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -44,7 +44,7 @@ export default interface DependencyContainer {
   ): DependencyContainer;
   resolve<T>(token: InjectionToken<T>): T;
   resolveAll<T>(token: InjectionToken<T>): T[];
-  isRegistered<T>(token: InjectionToken<T>): boolean;
+  isRegistered<T>(token: InjectionToken<T>, recursive?: boolean): boolean;
   reset(): void;
   createChildContainer(): DependencyContainer;
   createScope(): DependencyContainer;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export {default as constructor} from "./constructor";
 export {default as DependencyContainer} from "./dependency-container";
 export {default as Dictionary} from "./dictionary";
 export {default as RegistrationOptions} from "./registration-options";
+export {Lifetime} from "./registration-options";

--- a/src/types/registration-options.ts
+++ b/src/types/registration-options.ts
@@ -1,5 +1,12 @@
+export enum Lifetime {
+  TRANSIENT = "Transient",
+  SINGLETON = "Singleton",
+  SCOPED = "Scoped"
+}
+
 type RegistrationOptions = {
-  singleton: boolean;
+  lifetime?: Lifetime;
+  singleton?: boolean;
 };
 
 export default RegistrationOptions;


### PR DESCRIPTION
Finally I had some time to submit a proper PR with this feature.

This is my proposed implementation for the feature requested here #25.
Scoped lifetime behaves pretty much like a singleton, except it caches the resolved instance for every scoped container.

Ex:
```ts
class Foo {
  myString: string = "";
}

globalContainer.registerScoped(Foo, Foo);
const scope = globalContainer.createScope();

const foo1 = globalContainer.resolve(Foo);
const foo2 = scope.resolve(Foo);
const foo3 = scope.resolve(Foo);

console.log(foo1 == foo2) // false
console.log(foo2 == foo3) // true
```

### Changes
+ Add `scoped()` decorator;
+ Add `createScope()` method to DependencyContainer;
+ Add `registerScoped()` method to DependencyContainer;
+ Add parameter `recursive` to the method `isRegistered()` on DependencyContainer to allow checking if a dependecy is registered on a parent container.


Once this is reviewed, and if gets approved I'll update the PR with docs for this feature.