### PR TITLE
Factory aware of target class that resolves the factory's type.

### DIFF
--- a/src/decorators/auto-injectable.ts
+++ b/src/decorators/auto-injectable.ts
@@ -23,10 +23,10 @@ function autoInjectable(): (target: constructor<any>) => any {
               try {
                 if (isTokenDescriptor(type)) {
                   return type.multiple
-                    ? globalContainer.resolveAll(type.token)
-                    : globalContainer.resolve(type.token);
+                    ? globalContainer.resolveAll(type.token, target)
+                    : globalContainer.resolve(type.token, target);
                 }
-                return globalContainer.resolve(type);
+                return globalContainer.resolve(type, target);
               } catch (e) {
                 const argIndex = index + args.length;
 

--- a/src/factories/factory-function.ts
+++ b/src/factories/factory-function.ts
@@ -1,5 +1,9 @@
 import DependencyContainer from "../types/dependency-container";
+import {constructor} from "../types";
 
-type FactoryFunction<T> = (dependencyContainer: DependencyContainer) => T;
+type FactoryFunction<T> = (
+  dependencyContainer: DependencyContainer,
+  target?: constructor<T>
+) => T;
 
 export default FactoryFunction;

--- a/src/factories/instance-caching-factory.ts
+++ b/src/factories/instance-caching-factory.ts
@@ -1,13 +1,17 @@
 import DependencyContainer from "../types/dependency-container";
 import FactoryFunction from "./factory-function";
+import {constructor} from "../types";
 
 export default function instanceCachingFactory<T>(
   factoryFunc: FactoryFunction<T>
 ): FactoryFunction<T> {
   let instance: T;
-  return (dependencyContainer: DependencyContainer) => {
+  return (
+    dependencyContainer: DependencyContainer,
+    target?: constructor<T>
+  ) => {
     if (instance == undefined) {
-      instance = factoryFunc(dependencyContainer);
+      instance = factoryFunc(dependencyContainer, target);
     }
     return instance;
   };

--- a/src/factories/predicate-aware-class-factory.ts
+++ b/src/factories/predicate-aware-class-factory.ts
@@ -3,20 +3,26 @@ import constructor from "../types/constructor";
 import FactoryFunction from "./factory-function";
 
 export default function predicateAwareClassFactory<T>(
-  predicate: (dependencyContainer: DependencyContainer) => boolean,
+  predicate: (
+    dependencyContainer: DependencyContainer,
+    target?: constructor<T>
+  ) => boolean,
   trueConstructor: constructor<T>,
   falseConstructor: constructor<T>,
   useCaching = true
 ): FactoryFunction<T> {
   let instance: T;
   let previousPredicate: boolean;
-  return (dependencyContainer: DependencyContainer) => {
-    const currentPredicate = predicate(dependencyContainer);
+  return (
+    dependencyContainer: DependencyContainer,
+    target?: constructor<T>
+  ) => {
+    const currentPredicate = predicate(dependencyContainer, target);
     if (!useCaching || previousPredicate !== currentPredicate) {
       if ((previousPredicate = currentPredicate)) {
-        instance = dependencyContainer.resolve(trueConstructor);
+        instance = dependencyContainer.resolve(trueConstructor, target);
       } else {
-        instance = dependencyContainer.resolve(falseConstructor);
+        instance = dependencyContainer.resolve(falseConstructor, target);
       }
     }
     return instance;

--- a/src/providers/factory-provider.ts
+++ b/src/providers/factory-provider.ts
@@ -1,5 +1,6 @@
 import DependencyContainer from "../types/dependency-container";
 import Provider from "./provider";
+import {constructor} from "../types";
 
 /**
  * Provide a dependency using a factory.
@@ -7,7 +8,10 @@ import Provider from "./provider";
  * you need instance caching, your factory method must implement it.
  */
 export default interface FactoryProvider<T> {
-  useFactory: (dependencyContainer: DependencyContainer) => T;
+  useFactory: (
+    dependencyContainer: DependencyContainer,
+    target?: constructor<T>
+  ) => T;
 }
 
 export function isFactoryProvider<T>(

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -39,7 +39,9 @@ export default interface DependencyContainer {
     instance: T
   ): DependencyContainer;
   resolve<T>(token: InjectionToken<T>): T;
+  resolve<T>(token: InjectionToken<T>, parent?: constructor<any>): T;
   resolveAll<T>(token: InjectionToken<T>): T[];
+  resolveAll<T>(token: InjectionToken<T>, parent?: constructor<any>): T[];
   isRegistered<T>(token: InjectionToken<T>): boolean;
   reset(): void;
   createChildContainer(): DependencyContainer;


### PR DESCRIPTION
This pull request enables factory for resolving dependencies to see which class is using the factory to resolve the dependency.

For example, when you use factory to resolve `Logger` class, which contains parameter `name` in its constructor, you can provide parent's class name to automatically name the logger.

Example of final usage:
```typescript
export class Logger {
  constructor(private name: string) {}

  public info(message: string) {
    console.log(`[${this.name}] ${message}`);
  }
}

// New "target" argument in factory, which contains the constructor of parent class (or undefined, if resolved directly from container)
const loggerFactory: FactoryFunction<Logger> = (_, target) => new Logger(target ? target.name : 'Default');
container.register(Logger, { useFactory: loggerFactory });

@injectable()
export class TestClass {
  constructor(logger: Logger) {
    logger.info('test') // [TestClass] test
  }
}
```