### PR TITLE
Export unexported types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ if (typeof Reflect === "undefined" || !Reflect.getMetadata) {
   throw `tsyringe requires a reflect polyfill. Please add 'import "reflect-metadata"' to the top of your entry point.`;
 }
 
-export {DependencyContainer} from "./types";
+export {DependencyContainer, Lifecycle, RegistrationOptions} from "./types";
 export * from "./decorators";
 export * from "./factories";
 export * from "./providers";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export {default as constructor} from "./constructor";
 export {default as DependencyContainer} from "./dependency-container";
 export {default as Dictionary} from "./dictionary";
 export {default as RegistrationOptions} from "./registration-options";
+export {default as Lifecycle} from "./lifecycle";


### PR DESCRIPTION
Currently it's not possible to use the `@scoped` decorator because the Lifecycle enum is not exported.