### PR TITLE
Inject empty array with @injectAll() in case of unregistered string or symbol token

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ class Foo {
 Parameter decorator for array parameters where the array contents will come from the container.
 It will inject an array using the specified injection token to resolve the values.
 
+If nothing is registered for the specified token and the token is a string or a symbol, it will inject an empty array.
+If nothing is registered for the specified token and the token is a class constructor, it will inject an array
+with a single instance of the class.
+
 #### Usage
 
 ```typescript
@@ -368,7 +372,7 @@ const myFoo = container.resolve(Foo);
 const myBar = container.resolve<Bar>("Bar");
 ```
 
-You can also resolve all instances registered against a given token with `resolveAll()`.
+You can also resolve all instances registered against a given token with `**`resolveAll(`**)`.
 
 ```typescript
 const myBars = container.resolveAll<Bar>("Bar"); // myBars type is Bar[]

--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -205,10 +205,19 @@ test("resolves anonymous classes separately", () => {
 
 // --- resolveAll() ---
 
-test("fails to resolveAll unregistered dependency by name", () => {
-  expect(() => {
-    globalContainer.resolveAll("NotRegistered");
-  }).toThrow();
+test("resolves an empty array in case of unregistered dependency by name", () => {
+  const array = globalContainer.resolveAll("NotRegistered");
+  expect(Array.isArray(array)).toBeTruthy();
+  expect(array.length).toBe(0);
+});
+
+test("resolves an array of a single instance in case of unregistered dependency by class constructor", () => {
+  class Foo {}
+
+  const fooArray = globalContainer.resolveAll<Foo>(Foo);
+  expect(Array.isArray(fooArray)).toBeTruthy();
+  expect(fooArray.length).toBe(1);
+  expect(fooArray[0]).toBeInstanceOf(Foo);
 });
 
 test("resolves an array of transient instances bound to a single interface", () => {

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -239,7 +239,7 @@ class InternalDependencyContainer implements DependencyContainer {
     const registrations = this.getAllRegistrations(token);
 
     if (!registrations && isNormalToken(token)) {
-      throw `Attempted to resolve unregistered dependency token: ${token.toString()}`;
+      return [];
     }
 
     if (registrations) {


### PR DESCRIPTION
Closes: #63 

This PR introduces the following breaking change:

When using `@injectAll('myToken') private foo: Foo[]` and when nothing is registered for the specified token, it will inject an empty array instead of throwing an "Attempted to resolve unregistered dependency token: ${token.toString()}" error.

This is a breaking change because things that used to break (throwing an error) won't break anymore.

Also, it keeps the same behavior as before when the token is a class constructor and an array of a single instance of the class is injected.