### PR TITLE
Remove extra before in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add a polyfill for the Reflect API (examples below use reflect-metadata). You ca
 - [core-js (core-js/es7/reflect)](https://www.npmjs.com/package/core-js)
 - [reflection](https://www.npmjs.com/package/@abraham/reflection)
 
-The Reflect polyfill import should only be added once, and before before DI is used:
+The Reflect polyfill import should only be added once, and before DI is used:
 
 ```typescript
 // main.ts


### PR DESCRIPTION
Removal of extra `before` in README file.