### PR TITLE
Improve error messages information (#70)

### DIFF
--- a/src/__tests__/auto-injectable.test.ts
+++ b/src/__tests__/auto-injectable.test.ts
@@ -121,9 +121,8 @@ test("@autoInjectable throws a clear error if a dependency can't be resolved.", 
   class Foo {
     constructor(public myBar?: Bar) {}
   }
-
   expect(() => new Foo()).toThrow(
-    /Cannot inject the dependency myBar of Foo constructor. Error: TypeInfo/
+    /Cannot inject the dependency "myBar" at position #0 of "Foo" constructor\. Reason:\s+TypeInfo/
   );
 });
 

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,42 @@
+import {instance as globalContainer} from "../dependency-container";
+import {inject, injectable} from "../decorators";
+
+afterEach(() => {
+  globalContainer.reset();
+});
+
+test("Error message composition", () => {
+  class Ok {}
+
+  @injectable()
+  class C {
+    constructor(public s: any) {}
+  }
+
+  @injectable()
+  class B {
+    constructor(public c: C) {}
+  }
+
+  @injectable()
+  class A {
+    constructor(public d: Ok, public b: B) {}
+  }
+  expect(() => {
+    globalContainer.resolve(A);
+  }).toThrow(
+    /Cannot inject the dependency "b" at position #1 of "A" constructor. Reason:\s+Cannot inject the dependency "c" at position #0 of "B" constructor. Reason:\s+Cannot inject the dependency "s" at position #0 of "C" constructor. Reason:\s+TypeInfo not known for "Object"/
+  );
+});
+
+test("Param position", () => {
+  @injectable()
+  class A {
+    constructor(@inject("missing") public j: any) {}
+  }
+  expect(() => {
+    globalContainer.resolve(A);
+  }).toThrow(
+    /Cannot inject the dependency "j" at position #0 of "A" constructor. Reason:\s+Attempted to resolve unregistered dependency token: "missing"/
+  );
+});

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -22,10 +22,20 @@ test("Error message composition", () => {
   class A {
     constructor(public d: Ok, public b: B) {}
   }
+
   expect(() => {
     globalContainer.resolve(A);
   }).toThrow(
-    /Cannot inject the dependency "b" at position #1 of "A" constructor. Reason:\s+Cannot inject the dependency "c" at position #0 of "B" constructor. Reason:\s+Cannot inject the dependency "s" at position #0 of "C" constructor. Reason:\s+TypeInfo not known for "Object"/
+    new RegExp(
+      [
+        /Cannot inject the dependency "b" at position #1 of "A" constructor\. Reason:/,
+        /Cannot inject the dependency "c" at position #0 of "B" constructor\. Reason:/,
+        /Cannot inject the dependency "s" at position #0 of "C" constructor\. Reason:/,
+        /TypeInfo not known for "Object"/
+      ]
+        .map(x => x.source)
+        .join("\\s+")
+    )
   );
 });
 
@@ -34,9 +44,17 @@ test("Param position", () => {
   class A {
     constructor(@inject("missing") public j: any) {}
   }
+
   expect(() => {
     globalContainer.resolve(A);
   }).toThrow(
-    /Cannot inject the dependency "j" at position #0 of "A" constructor. Reason:\s+Attempted to resolve unregistered dependency token: "missing"/
+    new RegExp(
+      [
+        /Cannot inject the dependency "j" at position #0 of "A" constructor\. Reason:/,
+        /Attempted to resolve unregistered dependency token: "missing"/
+      ]
+        .map(x => x.source)
+        .join("\\s+")
+    )
   );
 });

--- a/src/decorators/auto-injectable.ts
+++ b/src/decorators/auto-injectable.ts
@@ -2,6 +2,7 @@ import constructor from "../types/constructor";
 import {getParamInfo} from "../reflection-helpers";
 import {instance as globalContainer} from "../dependency-container";
 import {isTokenDescriptor} from "../providers/injection-token";
+import {formatErrorCtor} from "../error-helpers";
 
 /**
  * Class decorator factory that replaces the decorated class' constructor with
@@ -29,16 +30,7 @@ function autoInjectable(): (target: constructor<any>) => any {
                 return globalContainer.resolve(type);
               } catch (e) {
                 const argIndex = index + args.length;
-
-                const [, params = null] =
-                  target.toString().match(/constructor\(([\w, ]+)\)/) || [];
-                const argName = params
-                  ? params.split(",")[argIndex]
-                  : `#${argIndex}`;
-
-                throw new Error(
-                  `Cannot inject the dependency ${argName} of ${target.name} constructor. ${e}`
-                );
+                throw new Error(formatErrorCtor(target, argIndex, e));
               }
             })
           )

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -8,7 +8,10 @@ import {
 } from "./providers";
 import Provider, {isProvider} from "./providers/provider";
 import FactoryProvider from "./providers/factory-provider";
-import InjectionToken, {isTokenDescriptor} from "./providers/injection-token";
+import InjectionToken, {
+  isTokenDescriptor,
+  TokenDescriptor
+} from "./providers/injection-token";
 import TokenProvider from "./providers/token-provider";
 import ValueProvider from "./providers/value-provider";
 import ClassProvider from "./providers/class-provider";
@@ -25,7 +28,9 @@ export type Registration<T = any> = {
   instance?: T;
 };
 
-export const typeInfo = new Map<constructor<any>, any[]>();
+export type ParamInfo = TokenDescriptor | InjectionToken<any>;
+
+export const typeInfo = new Map<constructor<any>, ParamInfo[]>();
 
 /** Dependency Container */
 class InternalDependencyContainer implements DependencyContainer {
@@ -348,7 +353,7 @@ class InternalDependencyContainer implements DependencyContainer {
   }
 
   private resolveParams<T>(context: ResolutionContext, ctor: constructor<T>) {
-    return (param: any, idx: number) => {
+    return (param: ParamInfo, idx: number) => {
       try {
         if (isTokenDescriptor(param)) {
           return param.multiple

--- a/src/error-helpers.ts
+++ b/src/error-helpers.ts
@@ -1,0 +1,27 @@
+import constructor from "./types/constructor";
+
+function formatDependency(params: string | null, idx: number): string {
+  if (params === null) {
+    return `at position #${idx}`;
+  }
+  const argName = params.split(",")[idx].trim();
+  return `"${argName}" at position #${idx}`;
+}
+
+function composeErrorMessage(msg: string, e: Error, indent = "    "): string {
+  return [msg, ...e.message.split("\n").map(l => indent + l)].join("\n");
+}
+
+export function formatErrorCtor(
+  ctor: constructor<any>,
+  paramIdx: number,
+  error: Error
+): string {
+  const [, params = null] =
+    ctor.toString().match(/constructor\(([\w, ]+)\)/) || [];
+  const dep = formatDependency(params, paramIdx);
+  return composeErrorMessage(
+    `Cannot inject the dependency ${dep} of "${ctor.name}" constructor. Reason:`,
+    error
+  );
+}

--- a/src/reflection-helpers.ts
+++ b/src/reflection-helpers.ts
@@ -1,10 +1,11 @@
 import Dictionary from "./types/dictionary";
 import constructor from "./types/constructor";
 import InjectionToken from "./providers/injection-token";
+import {ParamInfo} from "./dependency-container";
 
 export const INJECTION_TOKEN_METADATA_KEY = "injectionTokens";
 
-export function getParamInfo(target: constructor<any>): any[] {
+export function getParamInfo(target: constructor<any>): ParamInfo[] {
   const params: any[] = Reflect.getMetadata("design:paramtypes", target) || [];
   const injectionTokens: Dictionary<InjectionToken<any>> =
     Reflect.getOwnMetadata(INJECTION_TOKEN_METADATA_KEY, target) || {};


### PR DESCRIPTION
To address #70 handling composition of error messages with some helpers.

Example:
```javascript
  class Ok {}

  @injectable()
  class C {
    constructor(public s: any) {}
  }

  @injectable()
  class B {
    constructor(public c: C) {}
  }

  @injectable()
  class A {
    constructor(public d: Ok, public b: B) {}
  }

```

```
container.resolve(A)
```

Will throw an exception like this:

```
Cannot inject the dependency "b" at position #1 of "A" constructor. Reason:
    Cannot inject the dependency "c" at position #0 of "B" constructor. Reason:
        Cannot inject the dependency "s" at position #0 of "C" constructor. Reason:
            TypeInfo not known for "Object"
```
