### PR TITLE
handle circular dependencies

### DIFF
--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -5,3 +5,5 @@ export {default as registry} from "./registry";
 export {default as singleton} from "./singleton";
 export {default as injectAll} from "./inject-all";
 export {default as scoped} from "./scoped";
+export {default as lazyInject} from "./lazy-inject";
+export {default as lazyInjectAll} from "./lazy-inject-all";

--- a/src/decorators/lazy-inject-all.ts
+++ b/src/decorators/lazy-inject-all.ts
@@ -1,0 +1,11 @@
+import {InjectionToken} from "../providers";
+import {defineLazyInjectionTokenMetadata} from "../reflection-helpers";
+
+function lazyInjectAll(token: InjectionToken): PropertyDecorator {
+  return defineLazyInjectionTokenMetadata({
+    multiple: true,
+    token
+  });
+}
+
+export default lazyInjectAll;

--- a/src/decorators/lazy-inject.ts
+++ b/src/decorators/lazy-inject.ts
@@ -1,0 +1,11 @@
+import {InjectionToken} from "../providers";
+import {defineLazyInjectionTokenMetadata} from "../reflection-helpers";
+
+function lazyInject(token: InjectionToken): PropertyDecorator {
+  return defineLazyInjectionTokenMetadata({
+    multiple: false,
+    token
+  });
+}
+
+export default lazyInject;

--- a/src/reflection-helpers.ts
+++ b/src/reflection-helpers.ts
@@ -1,9 +1,12 @@
-import Dictionary from "./types/dictionary";
-import constructor from "./types/constructor";
-import InjectionToken from "./providers/injection-token";
 import {ParamInfo} from "./dependency-container";
+import InjectionToken, {TokenDescriptor} from "./providers/injection-token";
+import constructor from "./types/constructor";
+import Dictionary from "./types/dictionary";
+
+export type LazyInjectInfo = Map<string | symbol, TokenDescriptor>;
 
 export const INJECTION_TOKEN_METADATA_KEY = "injectionTokens";
+export const LAZY_INJECTION_TOKEN_METADATA_KEY = "tsyringe.lazyInjectionTokens";
 
 export function getParamInfo(target: constructor<any>): ParamInfo[] {
   const params: any[] = Reflect.getMetadata("design:paramtypes", target) || [];
@@ -31,6 +34,30 @@ export function defineInjectionTokenMetadata(
       INJECTION_TOKEN_METADATA_KEY,
       injectionTokens,
       target
+    );
+  };
+}
+
+export function getLazyInjectInfo(target: object): LazyInjectInfo {
+  return (
+    Reflect.getMetadata(LAZY_INJECTION_TOKEN_METADATA_KEY, target) || new Map()
+  );
+}
+
+export function defineLazyInjectionTokenMetadata(
+  tokenDescriptor: TokenDescriptor
+): PropertyDecorator {
+  return function(target, propertyKey) {
+    const lazyInjectionInfo: LazyInjectInfo =
+      Reflect.getOwnMetadata(
+        LAZY_INJECTION_TOKEN_METADATA_KEY,
+        target.constructor
+      ) || new Map();
+    lazyInjectionInfo.set(propertyKey, tokenDescriptor);
+    Reflect.defineMetadata(
+      LAZY_INJECTION_TOKEN_METADATA_KEY,
+      lazyInjectionInfo,
+      target.constructor
     );
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,11 @@
+export function memoize<T extends (...args: any[]) => any>(fn: T): T {
+  let wasRun = false;
+  let result!: ReturnType<T>;
+  return function(this: any, ...args: any[]) {
+    if (wasRun) {
+      return result;
+    }
+    wasRun = true;
+    return (result = fn.apply(this, args));
+  } as T;
+}


### PR DESCRIPTION
add @lazyInject & @lazyInjectAll decorators

```typescript
const IBar = Symbol("IBar");
  interface IBar {
    foo: Foo;
  }

  @injectable()
  class Foo {
    @lazyInject(IBar) bar!: IBar;
  }

  @injectable()
  class Bar implements IBar {
    constructor(@inject(Foo) public foo: Foo) {}
  }

  globalContainer.register(
    IBar,
    {
      useClass: Bar
    },
    {lifecycle: Lifecycle.Singleton}
  );

  const bar = globalContainer.resolve<IBar>(IBar);

  expect(bar.foo.bar).toBe(bar);
```