### PR TITLE
Add `.clearInstances()` method

### DIFF
--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -308,6 +308,38 @@ test("returns true for a registered token provider", () => {
   expect(globalContainer.isRegistered(Foo)).toBeTruthy();
 });
 
+// --- clearInstances() ---
+
+test("clears ValueProvider registrations", () => {
+  class Foo {}
+  const instance1 = new Foo();
+  globalContainer.registerInstance("Test", instance1);
+
+  expect(globalContainer.resolve("Test")).toBeInstanceOf(Foo);
+
+  globalContainer.clearInstances();
+
+  expect(() => {
+    globalContainer.resolve("Test");
+  }).toThrow();
+});
+
+test("clears cached instances from container.resolve() calls", () => {
+  @singleton()
+  class Foo {}
+  const instance1 = globalContainer.resolve(Foo);
+
+  globalContainer.clearInstances();
+
+  // Foo should still be registered as singleton
+  const instance2 = globalContainer.resolve(Foo);
+  const instance3 = globalContainer.resolve(Foo);
+
+  expect(instance1).not.toBe(instance2);
+  expect(instance2).toBe(instance3);
+  expect(instance3).toBeInstanceOf(Foo);
+});
+
 // --- @injectable ---
 
 test("@injectable resolves when not using DI", () => {

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -286,6 +286,22 @@ class InternalDependencyContainer implements DependencyContainer {
     this._registry.clear();
   }
 
+  public clearInstances(): void {
+    for (const [token, registrations] of this._registry.entries()) {
+      this._registry.setAll(
+        token,
+        registrations
+          // Clear ValueProvider registrations
+          .filter(registration => !isValueProvider(registration.provider))
+          // Clear instances
+          .map(registration => {
+            registration.instance = undefined;
+            return registration;
+          })
+      );
+    }
+  }
+
   public createChildContainer(): DependencyContainer {
     const childContainer = new InternalDependencyContainer(this);
 

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -69,5 +69,7 @@ export default interface DependencyContainer {
    * Clears all registered tokens
    */
   reset(): void;
+
+  clearInstances(): void;
   createChildContainer(): DependencyContainer;
 }


### PR DESCRIPTION
Closes: #83

This PR introduces the `container.clearInstances()` method for clearing the cached instances and registered `ValueProvider` values from the internal registry.

See https://github.com/microsoft/tsyringe/issues/28 for context.