### PR TITLE
Wrap constructor in a callback for `delay`. Fix #105

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,12 +481,12 @@ When the proxy object is used for the first time it will construct a real object
 ```typescript
 @injectable()
 export class Foo {
-  constructor(@inject(delay(Bar)) public bar: Bar) {}
+  constructor(@inject(delay(() => Bar)) public bar: Bar) {}
 }
 
 @injectable()
 export class Bar {
-  constructor(@inject(delay(Foo)) public foo: Foo) {}
+  constructor(@inject(delay(() => Foo)) public foo: Foo) {}
 }
 
 // construction of foo is possible
@@ -510,7 +510,7 @@ export interface IFoo {}
   {
     token: "IBar",
     // `DelayedConstructor` of Bar will be the token
-    useToken: delay(Bar)
+    useToken: delay(() => Bar)
   }
 ])
 export class Foo implements IFoo {
@@ -522,7 +522,7 @@ export interface IBar {}
 @registry([
   {
     token: "IFoo",
-    useToken: delay(Foo)
+    useToken: delay(() => Foo)
   }
 ])
 export class Bar implements IBar {

--- a/src/__tests__/fixtures/02-test-case-A02-lazy-injects-B02.ts
+++ b/src/__tests__/fixtures/02-test-case-A02-lazy-injects-B02.ts
@@ -4,5 +4,5 @@ import {delay} from "../../lazy-helpers";
 
 @injectable()
 export class A02 {
-  constructor(@inject(delay(B02)) public b: B02) {}
+  constructor(@inject(delay(() => B02)) public b: B02) {}
 }

--- a/src/__tests__/fixtures/02-test-case-B02-lazy-injects-A02.ts
+++ b/src/__tests__/fixtures/02-test-case-B02-lazy-injects-A02.ts
@@ -8,5 +8,5 @@ export class B02 {
   public prop = {
     defined: false
   };
-  constructor(@inject(delay(A02)) public a: A02) {}
+  constructor(@inject(delay(() => A02)) public a: A02) {}
 }

--- a/src/__tests__/fixtures/03-test-case-A03-lazy-injects-B03-interface.ts
+++ b/src/__tests__/fixtures/03-test-case-A03-lazy-injects-B03-interface.ts
@@ -10,7 +10,7 @@ export interface Ia03 {
 @registry([
   {
     token: "Ib03",
-    useToken: delay(B03)
+    useToken: delay(() => B03)
   }
 ])
 export class A03 implements Ia03 {

--- a/src/__tests__/fixtures/03-test-case-B03-lazy-injects-A03-interface.ts
+++ b/src/__tests__/fixtures/03-test-case-B03-lazy-injects-A03-interface.ts
@@ -10,7 +10,7 @@ export interface Ib03 {
 @registry([
   {
     token: "Ia03",
-    useToken: delay(A03)
+    useToken: delay(() => A03)
   }
 ])
 export class B03 implements Ib03 {

--- a/src/__tests__/inject-lazy-interfaces.tests.ts
+++ b/src/__tests__/inject-lazy-interfaces.tests.ts
@@ -4,7 +4,9 @@ import {B03} from "./fixtures/03-test-case-B03-lazy-injects-A03-interface";
 
 test("Lazy creation with proxies allow circular dependencies using interfaces", () => {
   const a = globalContainer.resolve(A03);
+  const b = globalContainer.resolve(B03);
   expect(a).toBeInstanceOf(A03);
   expect(a.b).toBeInstanceOf(B03);
+  expect(b.a).toBeInstanceOf(A03);
   expect(a.b.name).toBe("B03");
 });

--- a/src/__tests__/inject-lazy.tests.ts
+++ b/src/__tests__/inject-lazy.tests.ts
@@ -13,7 +13,7 @@ test("DelayedConstructor delays creation until first usage", () => {
       created = true;
     }
   }
-  const delayedConstructor = delay(Foo);
+  const delayedConstructor = delay(() => Foo);
   expect(delayedConstructor).toBeInstanceOf(DelayedConstructor);
   const foo: Foo = delayedConstructor.createProxy(Target => new Target());
   expect(created).toBe(false);
@@ -28,6 +28,7 @@ test("Lazy creation with proxies allow circular dependencies", () => {
   b.prop["defined"] = true;
   expect(a).toBeInstanceOf(A02);
   expect(a.b).toBeInstanceOf(B02);
+  expect(b.a).toBeInstanceOf(A02);
   expect(a.b.prop["defined"]).toBe(true);
   expect(a.b.name).toBe("B02");
 });

--- a/src/lazy-helpers.ts
+++ b/src/lazy-helpers.ts
@@ -14,7 +14,7 @@ export class DelayedConstructor<T> {
     "construct"
   ];
 
-  constructor(private delayedConstructor: constructor<T>) {}
+  constructor(private wrap: () => constructor<T>) {}
 
   public createProxy(createObject: (ctor: constructor<T>) => T): T {
     const target: object = {};
@@ -22,7 +22,7 @@ export class DelayedConstructor<T> {
     let value: T;
     const delayedObject: () => T = (): T => {
       if (!init) {
-        value = createObject(this.delayedConstructor);
+        value = createObject(this.wrap());
         init = true;
       }
       return value;
@@ -45,7 +45,12 @@ export class DelayedConstructor<T> {
 }
 
 export function delay<T>(
-  delayedConstructor: constructor<T>
+  wrappedConstructor: () => constructor<T>
 ): DelayedConstructor<T> {
-  return new DelayedConstructor<T>(delayedConstructor);
+  if (typeof wrappedConstructor === "undefined") {
+    throw new Error(
+      "Attempt to `delay` undefined. Constructor must be wrapped in a callback"
+    );
+  }
+  return new DelayedConstructor<T>(wrappedConstructor);
 }


### PR DESCRIPTION
Sorry but I don't see any way to solve #105 without changing the API of `delay` to the callback version again. I've added two assertions in tests for the problem described in #105.

The problem is that constructors are not fully defined at token register time. This happen when files are evaluated so we must delay evaluation properly inside a callback.
