### PR TITLE
Dependencies are not resolved for Subclasses with no constructor

### DIFF
--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -202,7 +202,18 @@ test("resolves anonymous classes separately", () => {
   expect(globalContainer.resolve(ctor1) instanceof ctor1).toBeTruthy();
   expect(globalContainer.resolve(ctor2) instanceof ctor2).toBeTruthy();
 });
-
+test("resolves dependencies of superclass with no constructor", () => {
+  class Dependency {}
+  @injectable()
+  class SuperClass {
+    constructor(public dependency: Dependency) {}
+  }
+  @injectable()
+  class SubClass extends SuperClass {}
+  expect(globalContainer.resolve(SubClass).dependency).toBeInstanceOf(
+    Dependency
+  );
+});
 // --- resolveAll() ---
 
 test("fails to resolveAll unregistered dependency by name", () => {

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -368,15 +368,13 @@ class InternalDependencyContainer implements DependencyContainer {
         this.resolve(target, context)
       );
     }
-
-    if (ctor.length === 0) {
-      return new ctor();
-    }
-
     const paramInfo = typeInfo.get(ctor);
-
     if (!paramInfo || paramInfo.length === 0) {
-      throw new Error(`TypeInfo not known for "${ctor.name}"`);
+      if (ctor.length === 0) {
+        return new ctor();
+      } else {
+        throw new Error(`TypeInfo not known for "${ctor.name}"`);
+      }
     }
 
     const params = paramInfo.map(this.resolveParams(context, ctor));


### PR DESCRIPTION
Dependencies are not resolved for Subclasses with no constructor
The library should support inheritance and work with any valid code. The library shouldn't force a developer to add a constructor where is not required by the language

Resolved by adding a check if there is a metadata firstly, which contains an information about superclass also, while a constructor.length is equal to 0.  