### PR TITLE
New decorator injectableAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ constructor injection.
     - [inject()](#inject)
     - [injectAll()](#injectall)
     - [scoped()](#scoped)
+    - [injectableAll()](#injectableall)
   - [Container](#container)
     - [Injection Token](#injection-token)
     - [Providers](#providers)
@@ -217,6 +218,25 @@ Class decorator factory that registers the class as a scoped dependency within t
 ```typescript
 @scoped(Lifecycle.ContainerScoped)
 class Foo {}
+```
+
+### injectableAll()
+
+ Class decorator factory that registers the classes with the same token within
+ the global container
+#### Usage
+
+```typescript
+@injectableAll('tags')
+class Foo {}
+
+@injectableAll('tags')
+class Bar {}
+
+@injectable()
+class FooBar {
+    constructor(@injectAll('tags') private fooBars: any[]) {}
+}
 ```
 
 ## Container

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -5,3 +5,5 @@ export {default as registry} from "./registry";
 export {default as singleton} from "./singleton";
 export {default as injectAll} from "./inject-all";
 export {default as scoped} from "./scoped";
+export {default as injectableAll} from "./injectable-all";
+

--- a/src/decorators/injectable-all.ts
+++ b/src/decorators/injectable-all.ts
@@ -1,0 +1,19 @@
+import constructor from "../types/constructor";
+import {instance as globalContainer} from "../dependency-container";
+import injectable from "./injectable";
+import InjectionToken from "../providers/injection-token";
+
+/**
+ * Class decorator factory that registers the classes with the same token within
+ * the global container.
+ *
+ * @return {Function} The class decorator
+ */
+function injectableAll<T>(token: InjectionToken<any>): (target: constructor<T>) => void {
+  return function(target: constructor<T>): void {
+    injectable()(target);
+    globalContainer.register(token, target)
+  };
+}
+
+export default injectableAll;


### PR DESCRIPTION
## Description

Howdy!

I want to open discussion about PoC of injectableAll decorator. I guess it's still missing feature when we have injectAll and don't have any decorator to aggregate injectables under one token.

```typescript
@injectableAll('tags')
class Foo {}
@injectableAll('tags')
class Bar {}
@injectable()
class FooBar {
    constructor(@injectAll('tags') private fooBars: any[]) {}
}
```

(eg. refer PR https://github.com/microsoft/tsyringe/pull/40 )

I created working implementation in this PR, but it's still more PoC than actuall implementation for missing decorator, so let's discuss!