### PR TITLE
Prevent registry cycles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,14 +2,8 @@
   "eslint.validate": [
     "javascript",
     "javascriptreact",
-    {
-      "language": "typescript",
-      "autoFix": true
-    },
-    {
-      "language": "typescriptreact",
-      "autoFix": true
-    }
+    "typescript",
+    "typescriptreact"
   ],
   "files.exclude": {
     "**/.git": true,
@@ -20,18 +14,21 @@
     "**/node_modules": true
   },
   "eslint.packageManager": "yarn",
-  "eslint.autoFixOnSave": true,
   "[javascript]": {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": false
   },
   "[javascriptreact]": {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": false
   },
   "[typescript]": {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": false
   },
   "[typescriptreact]": {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": false
   },
   "markdown.extension.toc.levels": "1..3",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -167,6 +167,21 @@ test("registerType() allows for names to be registered for a given type", () => 
   expect(globalContainer.resolve<Bar>("CoolName") instanceof Bar).toBeTruthy();
 });
 
+test("registerType() doesn't allow tokens to point to themselves", () => {
+  expect(() => globalContainer.registerType("Bar", "Bar")).toThrowError(
+    "Token registration cycle detected!"
+  );
+});
+
+test("registerType() doesn't allow registration cycles", () => {
+  globalContainer.registerType("Bar", "Foo");
+  globalContainer.registerType("Foo", "FooBar");
+
+  expect(() => globalContainer.registerType("FooBar", "Bar")).toThrowError(
+    "Token registration cycle detected!"
+  );
+});
+
 test("executes a registered factory each time resolve is called", () => {
   const factoryMock = jest.fn();
   globalContainer.register("Test", {useFactory: factoryMock});


### PR DESCRIPTION
Fixes #118 

This changes the register method to check if there is a TokenProvider cycle which would cause an infinite resolution.

Example output:
```
Token registration cycle detected! FooBar -> Bar -> Foo -> FooBar
```