### PR TITLE
Make `Object.keys` work on proxies returned by `delay()`

### DIFF
--- a/src/__tests__/inject-lazy.tests.ts
+++ b/src/__tests__/inject-lazy.tests.ts
@@ -32,3 +32,14 @@ test("Lazy creation with proxies allow circular dependencies", () => {
   expect(a.b.prop["defined"]).toBe(true);
   expect(a.b.name).toBe("B02");
 });
+
+test("Lazily created proxy allows iterating over keys of the original service", () => {
+  const a = globalContainer.resolve(A02);
+  const b = globalContainer.resolve(B02);
+  expect(a).toBeInstanceOf(A02);
+  expect(b).toBeInstanceOf(B02);
+  expect(Object.keys(a)).toStrictEqual(["b"]);
+  expect(Object.keys(b)).toStrictEqual(["a", "name", "prop"]);
+  expect(Object.getOwnPropertyNames(a)).toStrictEqual(["b"]);
+  expect(Object.getOwnPropertyNames(b)).toStrictEqual(["a", "name", "prop"]);
+});

--- a/src/lazy-helpers.ts
+++ b/src/lazy-helpers.ts
@@ -11,7 +11,8 @@ export class DelayedConstructor<T> {
     "set",
     "deleteProperty",
     "apply",
-    "construct"
+    "construct",
+    "ownKeys"
   ];
 
   constructor(private wrap: () => constructor<T>) {}


### PR DESCRIPTION
Closes #147 

I just made my own fork to test my change and it worked exactly as expected:

![image](https://user-images.githubusercontent.com/6885927/101970296-9b190080-3bf7-11eb-82df-b354e0ffd749.png)

I couldn't find any tests for testing this specifically so I didn't add anything. Let me know if you want me to include the tests also.