### PR TITLE
Default values for @inject()

### DIFF
--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -680,6 +680,55 @@ test("allows explicit array dependencies to be resolved by inject decorator", ()
   expect(bar.foo === fooArray).toBeTruthy();
 });
 
+test("allows inject to provide a default value, which will be used if not registered in other ways", () => {
+  @injectable()
+  class Foo {}
+
+  const fooArray = [new Foo()];
+
+  @injectable()
+  class Bar {
+    constructor(@inject("FooArray", {useValue: fooArray}) public foo: Foo[]) {}
+  }
+
+  globalContainer.register<Bar>(Bar, {useClass: Bar});
+
+  const bar = globalContainer.resolve<Bar>(Bar);
+  expect(bar.foo === fooArray).toBeTruthy();
+});
+
+test("allows inject to provide a default value, if injected afterwards it will be overwritten", () => {
+  @injectable()
+  class Bar {
+    constructor(
+      @inject("MyString", {useValue: "MyDefaultString"}) public foo: string
+    ) {}
+  }
+  const str = "NewString";
+  globalContainer.register("MyString", {useValue: str});
+
+  globalContainer.register<Bar>(Bar, {useClass: Bar});
+
+  const bar = globalContainer.resolve<Bar>(Bar);
+  expect(bar.foo === str).toBeTruthy();
+});
+
+test("allows inject to have other kinds of provider", () => {
+  @injectable()
+  class Bar implements IBar {
+    public value = "";
+  }
+
+  @injectable()
+  class FooWithInterface {
+    constructor(@inject("IBar", {useClass: Bar}) public myBar: IBar) {}
+  }
+
+  const myFoo = globalContainer.resolve(FooWithInterface);
+
+  expect(myFoo.myBar instanceof Bar).toBeTruthy();
+});
+
 // --- @injectAll ---
 
 test("injects all dependencies bound to a given interface", () => {

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -6,7 +6,7 @@ import {defineInjectionTokenMetadata} from "../reflection-helpers";
 /**
  * Parameter decorator factory that allows for interface information to be stored in the constructor's metadata.
  *
- * If a defaultValue is given it will be registered into the global container.
+ * If a defaultProvider is given it will be registered into the global container.
  *
  * @return {Function} The parameter decorator
  */

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -1,14 +1,22 @@
-import {defineInjectionTokenMetadata} from "../reflection-helpers";
+import {instance as globalContainer} from "../dependency-container";
+import {Provider} from "../providers";
 import InjectionToken from "../providers/injection-token";
+import {defineInjectionTokenMetadata} from "../reflection-helpers";
 
 /**
- * Parameter decorator factory that allows for interface information to be stored in the constructor's metadata
+ * Parameter decorator factory that allows for interface information to be stored in the constructor's metadata.
+ *
+ * If a defaultValue is given it will be registered into the global container.
  *
  * @return {Function} The parameter decorator
  */
 function inject(
-  token: InjectionToken<any>
+  token: InjectionToken<any>,
+  defaultProvider?: Provider<any>
 ): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+  if (defaultProvider !== undefined) {
+    globalContainer.register(token, defaultProvider as any);
+  }
   return defineInjectionTokenMetadata(token);
 }
 


### PR DESCRIPTION
Even though there is already the registry, where we can set the providers for the injections. It was discussed in a not so recent issue that the possibility of having default or optional dependencies would be interesting. Since I have not seen it being implemented I came up with this simple first implementation. It does more or less the same that `@registry()` does but within the `@inject()` decorator, which will allow for simpler code I believe.