### PR TITLE
add instance per container factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,20 @@ import {instanceCachingFactory} from "tsyringe";
 }
 ```
 
+##### instancePerContainerCachingFactory
+
+This factory is used to lazy construct an object and cache result per `DependencyContainer`, returning the single instance for each subsequent
+resolution from a single container. This is very similar to `@scoped(Lifecycle.ContainerScoped)`
+
+```typescript
+import {instancePerContainerCachingFactory} from "tsyringe";
+
+{
+  token: "ContainerScopedFoo";
+  useFactory: instancePerContainerCachingFactory<Foo>(c => c.resolve(Foo));
+}
+```
+
 ##### predicateAwareClassFactory
 
 This factory is used to provide conditional behavior upon resolution. It caches the result by default, but

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -1,5 +1,8 @@
 export {default as FactoryFunction} from "./factory-function";
 export {default as instanceCachingFactory} from "./instance-caching-factory";
 export {
+  default as instancePerContainerCachingFactory
+} from "./instance-per-container-caching-factory";
+export {
   default as predicateAwareClassFactory
 } from "./predicate-aware-class-factory";

--- a/src/factories/instance-per-container-caching-factory.ts
+++ b/src/factories/instance-per-container-caching-factory.ts
@@ -1,0 +1,16 @@
+import DependencyContainer from "../types/dependency-container";
+import FactoryFunction from "./factory-function";
+
+export default function instancePerContainerCachingFactory<T>(
+  factoryFunc: FactoryFunction<T>
+): FactoryFunction<T> {
+  const cache = new WeakMap<DependencyContainer, T>();
+  return (dependencyContainer: DependencyContainer) => {
+    let instance = cache.get(dependencyContainer);
+    if (instance == undefined) {
+      instance = factoryFunc(dependencyContainer);
+      cache.set(dependencyContainer, instance);
+    }
+    return instance;
+  };
+}


### PR DESCRIPTION
provides another factory pattern akin to `@scoped(Lifecycle.ContainerScoped)`. This uses `WeakMap` to store the cache in the closure. an alternative implementation for #140 