### PR TITLE
Feature - Unregister a token

### DIFF
--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -370,6 +370,43 @@ test("clears cached instances from container.resolve() calls", () => {
   expect(instance3).toBeInstanceOf(Foo);
 });
 
+// --- unregister() ---
+
+test("unregister all instances", () => {
+  class Foo {}
+  const instance1 = new Foo();
+  globalContainer.registerInstance("Test", instance1);
+
+  expect(globalContainer.resolve("Test")).toBeInstanceOf(Foo);
+
+  globalContainer.unregisterAll();
+
+  expect(() => {
+    globalContainer.resolve("Test");
+  }).toThrow();
+});
+
+test("unregister a single instance", () => {
+  class Foo {}
+
+  const instance1 = new Foo();
+  const instance2 = new Foo();
+
+  globalContainer.registerInstance("Test1", instance1);
+  globalContainer.registerInstance("Test2", instance2);
+
+  expect(globalContainer.resolve("Test1")).toBeInstanceOf(Foo);
+  expect(globalContainer.resolve("Test2")).toBeInstanceOf(Foo);
+
+  globalContainer.unregister("Test1");
+
+  expect(globalContainer.resolve("Test2")).toBeInstanceOf(Foo);
+
+  expect(() => {
+    globalContainer.resolve("Test1");
+  }).toThrow();
+});
+
 // --- @injectable ---
 
 test("@injectable resolves when not using DI", () => {

--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -407,6 +407,12 @@ test("unregister a single instance", () => {
   }).toThrow();
 });
 
+test("fails to delete unregistered dependency by name", () => {
+  expect(() => {
+    globalContainer.unregister("NotRegistered");
+  }).toThrow();
+});
+
 // --- @injectable ---
 
 test("@injectable resolves when not using DI", () => {

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -381,6 +381,14 @@ class InternalDependencyContainer implements DependencyContainer {
   }
 
   public unregister<T>(token: InjectionToken<T>): void {
+    const registration = this.getRegistration(token);
+
+    if (!registration) {
+      throw new Error(
+        `Attempted to delete unregistered dependency token: "${token.toString()}"`
+      );
+    }
+
     this._registry.delete(token);
     this.interceptors.preResolution.delete(token);
     this.interceptors.postResolution.delete(token);

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -374,6 +374,18 @@ class InternalDependencyContainer implements DependencyContainer {
     this.interceptors.postResolution.clear();
   }
 
+  public unregisterAll(): void {
+    this._registry.clear();
+    this.interceptors.preResolution.clear();
+    this.interceptors.postResolution.clear();
+  }
+
+  public unregister<T>(token: InjectionToken<T>): void {
+    this._registry.delete(token);
+    this.interceptors.preResolution.delete(token);
+    this.interceptors.postResolution.delete(token);
+  }
+
   public clearInstances(): void {
     for (const [token, registrations] of this._registry.entries()) {
       this._registry.setAll(

--- a/src/registry-base.ts
+++ b/src/registry-base.ts
@@ -36,6 +36,10 @@ export default abstract class RegistryBase<T> {
     this._registryMap.clear();
   }
 
+  public delete(key: InjectionToken<any>): void {
+    this._registryMap.delete(key);
+  }
+
   private ensure(key: InjectionToken<any>): void {
     if (!this._registryMap.has(key)) {
       this._registryMap.set(key, []);

--- a/src/types/dependency-container.ts
+++ b/src/types/dependency-container.ts
@@ -94,6 +94,9 @@ export default interface DependencyContainer {
    */
   reset(): void;
 
+  unregisterAll(): void;
+  unregister<T>(token: InjectionToken<T>): void;
+
   clearInstances(): void;
   createChildContainer(): DependencyContainer;
 


### PR DESCRIPTION
There are features in tsyringe for removing/cleaning all instances. It is not possible to choose a specific token to delete.

This pull request enables unregister a token. Solving two issues:

- https://github.com/microsoft/tsyringe/issues/96
- https://github.com/microsoft/tsyringe/issues/82

**Example**
```
interface ILogger {
  type: string,
  message: string
}

@injectable()
export class TestClass {
  constructor(private logger: ILogger) { }

  public info() {
    console.log(`[${this.logger.type}] ${this.logger.message}`);
  }
}

const instance1 = new TestClass({ type: "info", message: "test message info" });
const instance2 = new TestClass({ type: "error", message: "test message error" });

container.register("TestClass1", { useValue: instance1 });
container.register("TestClass2", { useValue: instance2 });

container.unregister("TestClass2");

const test1 = container.resolve<TestClass>("TestClass1");
test1.info();

const test2 = container.resolve<TestClass>("TestClass2");
test2.info();
```

The `test1` should log the message without any problems, however the `test2` will return an error message: `Attempted to resolve unregistered dependency token...`
Because unregister removed the corresponding key.