### PR TITLE
Move ctor param info from global map to metadata. Fixes #161

### DIFF
--- a/src/decorators/injectable.ts
+++ b/src/decorators/injectable.ts
@@ -1,6 +1,5 @@
 import constructor from "../types/constructor";
-import {getParamInfo} from "../reflection-helpers";
-import {typeInfo} from "../dependency-container";
+import {getParamInfo, PARAM_INFOS_METADATA_KEY} from "../reflection-helpers";
 
 /**
  * Class decorator factory that allows the class' dependencies to be injected
@@ -10,7 +9,9 @@ import {typeInfo} from "../dependency-container";
  */
 function injectable<T>(): (target: constructor<T>) => void {
   return function(target: constructor<T>): void {
-    typeInfo.set(target, getParamInfo(target));
+    const paramInfo = getParamInfo(target);
+
+    Reflect.defineMetadata(PARAM_INFOS_METADATA_KEY, paramInfo, target);
   };
 }
 

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -31,6 +31,7 @@ import {DelayedConstructor} from "./lazy-helpers";
 import Disposable, {isDisposable} from "./types/disposable";
 import InterceptorOptions from "./types/interceptor-options";
 import Interceptors from "./interceptors";
+import {PARAM_INFOS_METADATA_KEY} from "./reflection-helpers";
 
 export type Registration<T = any> = {
   provider: Provider<T>;
@@ -39,8 +40,6 @@ export type Registration<T = any> = {
 };
 
 export type ParamInfo = TokenDescriptor | InjectionToken<any>;
-
-export const typeInfo = new Map<constructor<any>, ParamInfo[]>();
 
 /** Dependency Container */
 class InternalDependencyContainer implements DependencyContainer {
@@ -519,7 +518,7 @@ class InternalDependencyContainer implements DependencyContainer {
     }
 
     const instance: T = (() => {
-      const paramInfo = typeInfo.get(ctor);
+      const paramInfo = Reflect.getMetadata(PARAM_INFOS_METADATA_KEY, ctor);
       if (!paramInfo || paramInfo.length === 0) {
         if (ctor.length === 0) {
           return new ctor();

--- a/src/reflection-helpers.ts
+++ b/src/reflection-helpers.ts
@@ -5,6 +5,7 @@ import {ParamInfo} from "./dependency-container";
 import Transform from "./types/transform";
 
 export const INJECTION_TOKEN_METADATA_KEY = "injectionTokens";
+export const PARAM_INFOS_METADATA_KEY = "paramInfos";
 
 export function getParamInfo(target: constructor<any>): ParamInfo[] {
   const params: any[] = Reflect.getMetadata("design:paramtypes", target) || [];


### PR DESCRIPTION
Hi there.

This PR moves the paramInfos acquired by the `injectable()` decorator from the global typeInfo map to constructor/class metadata.

That fixes a `TypeInfo not known for ...`  bug occurring in an environment where a library with injectable dependencies is linked using symlinks (npm-link).

In this special environment, globals are not shared between the library and the main project, therefore the typeInfos populated by the injectable() decorator weren't accessible before to the main project.

Due to this unfavorable side-effect of the npm-link, the `registry()` and `autoInjectable()` decorators will still be broken because their functionalities require direct access to the global container instance.

Minimal repo reproducing the issue in the initial commit: https://github.com/florian-g2/npm-link-missing-globals