### PR TITLE
refine value provider check if user passes a 'undefined' value

### DIFF
--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -553,6 +553,13 @@ test("registers by value provider", () => {
   expect(globalContainer.isRegistered(registration.token)).toBeTruthy();
 });
 
+test("value provider with 'undefined' value should work fine", () => {
+  globalContainer.register("Foo", {
+    useValue: undefined
+  });
+  expect(globalContainer.resolve("Foo")).toBe(undefined);
+});
+
 test("registers by token provider", () => {
   const registration = {
     token: "IBar",

--- a/src/providers/value-provider.ts
+++ b/src/providers/value-provider.ts
@@ -7,5 +7,5 @@ export default interface ValueProvider<T> {
 export function isValueProvider<T>(
   provider: Provider<T>
 ): provider is ValueProvider<T> {
-  return (provider as ValueProvider<T>).useValue != undefined;
+  return Object.prototype.hasOwnProperty.call(provider, "useValue");
 }


### PR DESCRIPTION
If user pass { useValue: undefined }, isProvider returns false,
causing https://github.com/microsoft/tsyringe/blob/f738999f3058b223bdb81dada0164a358db2460e/src/dependency-container.ts#L91 treat the object as a class

<!-- gk-ai-analysis-start:2f637db5af20edd7ca808c4a26e15d03adf29551 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiUmVmaW5lIGBpc1ZhbHVlUHJvdmlkZXJgIHRvIGNvcnJlY3RseSBpZGVudGlmeSB2YWx1ZSBwcm92aWRlcnMgZXZlbiB3aGVuIHRoZWlyIGB1c2VWYWx1ZWAgaXMgYHVuZGVmaW5lZGAuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiVXNlIGhhc093blByb3BlcnR5IGZvciB2YWx1ZSBwcm92aWRlciBjaGVjayIsImRlc2NyaXB0aW9uIjoiVGhlIGNoZWNrIGZvciBgaXNWYWx1ZVByb3ZpZGVyYCBoYXMgYmVlbiBjaGFuZ2VkIGZyb20gY2hlY2tpbmcgaWYgYHVzZVZhbHVlICE9IHVuZGVmaW5lZGAgdG8gY2hlY2tpbmcgaWYgdGhlIGB1c2VWYWx1ZWAgcHJvcGVydHkgZXhpc3RzIG9uIHRoZSBvYmplY3QuIFRoaXMgYWxsb3dzIHVzZXJzIHRvIHJlZ2lzdGVyIHZhbHVlIHByb3ZpZGVycyB3aXRoIGFuIGV4cGxpY2l0IGB1bmRlZmluZWRgIHZhbHVlLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJzcmMvcHJvdmlkZXJzL3ZhbHVlLXByb3ZpZGVyLnRzIiwibGluZVN0YXJ0Ijo3LCJsaW5lRW5kIjoxMH1dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:2f637db5af20edd7ca808c4a26e15d03adf29551 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/microsoft/tsyringe/pull/205?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->