### PR TITLE
fix: allow `propertyKey` to be undefined

### DIFF
--- a/src/decorators/auto-injectable.ts
+++ b/src/decorators/auto-injectable.ts
@@ -56,7 +56,7 @@ function autoInjectable(): (target: constructor<any>) => any {
                 return globalContainer.resolve(type);
               } catch (e) {
                 const argIndex = index + args.length;
-                throw new Error(formatErrorCtor(target, argIndex, e));
+                throw new Error(formatErrorCtor(target, argIndex, e as Error));
               }
             })
           )

--- a/src/decorators/inject-all-with-transform.ts
+++ b/src/decorators/inject-all-with-transform.ts
@@ -14,7 +14,11 @@ function injectAllWithTransform(
   token: InjectionToken<any>,
   transformer: InjectionToken<Transform<[any], any>>,
   ...args: any[]
-): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+): (
+  target: any,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number
+) => any {
   const data: TokenDescriptor | TransformDescriptor = {
     token,
     multiple: true,

--- a/src/decorators/inject-all.ts
+++ b/src/decorators/inject-all.ts
@@ -8,7 +8,11 @@ import InjectionToken, {TokenDescriptor} from "../providers/injection-token";
  */
 function injectAll(
   token: InjectionToken<any>
-): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+): (
+  target: any,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number
+) => any {
   const data: TokenDescriptor = {token, multiple: true};
   return defineInjectionTokenMetadata(data);
 }

--- a/src/decorators/inject-with-transform.ts
+++ b/src/decorators/inject-with-transform.ts
@@ -13,7 +13,11 @@ function injectWithTransform(
   token: InjectionToken<any>,
   transformer: InjectionToken<Transform<any, any>>,
   ...args: any[]
-): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+): (
+  target: any,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number
+) => any {
   return defineInjectionTokenMetadata(token, {
     transformToken: transformer,
     args: args

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -8,7 +8,11 @@ import InjectionToken from "../providers/injection-token";
  */
 function inject(
   token: InjectionToken<any>
-): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+): (
+  target: any,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number
+) => any {
   return defineInjectionTokenMetadata(token);
 }
 

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -567,7 +567,7 @@ class InternalDependencyContainer implements DependencyContainer {
         }
         return this.resolve(param, context);
       } catch (e) {
-        throw new Error(formatErrorCtor(ctor, idx, e));
+        throw new Error(formatErrorCtor(ctor, idx, e as Error));
       }
     };
   }

--- a/src/reflection-helpers.ts
+++ b/src/reflection-helpers.ts
@@ -20,10 +20,14 @@ export function getParamInfo(target: constructor<any>): ParamInfo[] {
 export function defineInjectionTokenMetadata(
   data: any,
   transform?: {transformToken: InjectionToken<Transform<any, any>>; args: any[]}
-): (target: any, propertyKey: string | symbol, parameterIndex: number) => any {
+): (
+  target: any,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number
+) => any {
   return function(
     target: any,
-    _propertyKey: string | symbol,
+    _propertyKey: string | symbol | undefined,
     parameterIndex: number
   ): any {
     const descriptors: Dictionary<InjectionToken<any> | TokenDescriptor> =


### PR DESCRIPTION
## Description

Typescript 5 fixed a bug in the decorator parameter type check that was causing decorators from tsyringe to fail to build. This fix allows for the `propertyKey` parameter to be undefined.

I'm not an experienced programmer, so if there's something wrong, please let me know. 

Fixes: #221