### PR TITLE
Adds support + test for isOptional argument in @injectAll decorator

### DIFF
--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -715,6 +715,21 @@ test("injects all dependencies bound to a given interface", () => {
   expect(bar.foo[1]).toBeInstanceOf(FooImpl2);
 });
 
+test("does not throw when injecting all dependencies bound to a given interface if the isOptional property is set to true", () => {
+  interface Foo {
+    str: string;
+  }
+
+  @injectable()
+  class Bar {
+    constructor(@injectAll("Foo", true) public foo: Foo[]) {}
+  }
+
+  const bar = globalContainer.resolve<Bar>(Bar);
+  expect(Array.isArray(bar.foo)).toBeTruthy();
+  expect(bar.foo.length).toBe(0);
+});
+
 test("allows array dependencies to be resolved if a single instance is in the container", () => {
   @injectable()
   class Foo {}

--- a/src/decorators/inject-all.ts
+++ b/src/decorators/inject-all.ts
@@ -7,13 +7,14 @@ import InjectionToken, {TokenDescriptor} from "../providers/injection-token";
  * @return {Function} The parameter decorator
  */
 function injectAll(
-  token: InjectionToken<any>
+  token: InjectionToken<any>,
+  isOptional?: boolean
 ): (
   target: any,
   propertyKey: string | symbol | undefined,
   parameterIndex: number
 ) => any {
-  const data: TokenDescriptor = {token, multiple: true};
+  const data: TokenDescriptor = {token, multiple: true, isOptional};
   return defineInjectionTokenMetadata(data);
 }
 

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -347,13 +347,17 @@ class InternalDependencyContainer implements DependencyContainer {
 
   public resolveAll<T>(
     token: InjectionToken<T>,
-    context: ResolutionContext = new ResolutionContext()
+    context: ResolutionContext = new ResolutionContext(),
+    isOptional = false
   ): T[] {
     this.ensureNotDisposed();
 
     const registrations = this.getAllRegistrations(token);
 
     if (!registrations && isNormalToken(token)) {
+      if (isOptional) {
+        return [];
+      }
       throw new Error(
         `Attempted to resolve unregistered dependency token: "${token.toString()}"`
       );
@@ -547,7 +551,11 @@ class InternalDependencyContainer implements DependencyContainer {
           if (isTransformDescriptor(param)) {
             return param.multiple
               ? this.resolve(param.transform).transform(
-                  this.resolveAll(param.token),
+                  this.resolveAll(
+                    param.token,
+                    new ResolutionContext(),
+                    param.isOptional
+                  ),
                   ...param.transformArgs
                 )
               : this.resolve(param.transform).transform(
@@ -556,7 +564,11 @@ class InternalDependencyContainer implements DependencyContainer {
                 );
           } else {
             return param.multiple
-              ? this.resolveAll(param.token)
+              ? this.resolveAll(
+                  param.token,
+                  new ResolutionContext(),
+                  param.isOptional
+                )
               : this.resolve(param.token, context);
           }
         } else if (isTransformDescriptor(param)) {

--- a/src/providers/injection-token.ts
+++ b/src/providers/injection-token.ts
@@ -43,6 +43,7 @@ export function isConstructorToken(
 export interface TokenDescriptor {
   token: InjectionToken<any>;
   multiple: boolean;
+  isOptional?: boolean;
 }
 
 export interface TransformDescriptor {


### PR DESCRIPTION
Adds support for passing a isOptional argument to `@injectAll`, preventing throwing when requested.

Issue: #63 