### PR TITLE
Adds the ability to register additional tokens via the @injectable decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,22 @@ class MyRegistry {}
 const myBars = container.resolveAll<Bar>("Bar"); // myBars type is Bar[]
 ```
 
+You can also add one or more `InjectionToken` to the registration of your class directly in the `@injectable()` decorator:
+
+```typescript
+interface Bar {}
+
+@injectable({token: "Bar"})
+class Foo implements Bar {}
+@injectable({token: ["Bar", "Bar2"]})
+class Baz implements Bar {}
+
+class MyRegistry {}
+
+const myBars = container.resolveAll<Bar>("Bar"); // myBars type is Bar[], contains 2 instances
+const myBars2 = container.resolveAll<Bar>("Bar2"); // myBars2 type is Bar[], contains 1 instance
+```
+
 ### IsRegistered
 You can check if a token is registered in the container using `isRegistered()`.
 

--- a/src/__tests__/global-container.test.ts
+++ b/src/__tests__/global-container.test.ts
@@ -277,6 +277,78 @@ test("resolves all transient instances when not registered", () => {
   expect(foo1[0]).not.toBe(foo2[0]);
 });
 
+test("resolves all dependencies that provided an additional token in the @injectable() decorator", () => {
+  interface Bar {
+    value(): string;
+  }
+
+  @injectable({token: "Bar"})
+  class Foo implements Bar {
+    value(): string {
+      return "foo";
+    }
+  }
+
+  const foo = globalContainer.resolveAll<Bar>("Bar");
+  expect(Array.isArray(foo)).toBeTruthy();
+  expect(foo[0] instanceof Foo).toBeTruthy();
+});
+
+test("resolves all dependencies that provided additional tokens in the @injectable() decorator", () => {
+  interface Bar {
+    value(): string;
+  }
+
+  interface TestInterface {
+    test(): string;
+  }
+
+  @injectable({token: ["Bar", "TestInterface"]})
+  class Foo implements Bar, TestInterface {
+    value(): string {
+      return "foo";
+    }
+
+    test(): string {
+      return "test";
+    }
+  }
+
+  const foo = globalContainer.resolveAll<Bar>("Bar");
+  expect(Array.isArray(foo)).toBeTruthy();
+  expect(foo[0] instanceof Foo).toBeTruthy();
+
+  const foo2 = globalContainer.resolveAll<TestInterface>("TestInterface");
+  expect(Array.isArray(foo2)).toBeTruthy();
+  expect(foo2[0] instanceof Foo).toBeTruthy();
+});
+
+test("resolves all dependencies that provided additional tokens in the @injectable() decorator", () => {
+  interface Bar {
+    value(): string;
+  }
+
+  @injectable({token: "Bar"})
+  class Foo implements Bar {
+    value(): string {
+      return "foo";
+    }
+  }
+
+  @injectable({token: "Bar"})
+  class Baz implements Bar {
+    value(): string {
+      return "baz";
+    }
+  }
+
+  const bars = globalContainer.resolveAll<Bar>("Bar");
+  expect(Array.isArray(bars)).toBeTruthy();
+  expect(bars.length).toBe(2);
+  expect(bars[0] instanceof Foo).toBeTruthy();
+  expect(bars[1] instanceof Baz).toBeTruthy();
+});
+
 // --- isRegistered() ---
 
 test("returns true for a registered singleton class", () => {

--- a/src/decorators/injectable.ts
+++ b/src/decorators/injectable.ts
@@ -1,6 +1,8 @@
 import constructor from "../types/constructor";
 import {getParamInfo} from "../reflection-helpers";
 import {typeInfo} from "../dependency-container";
+import InjectionToken from "../providers/injection-token";
+import {instance as globalContainer} from "../dependency-container";
 
 /**
  * Class decorator factory that allows the class' dependencies to be injected
@@ -8,9 +10,21 @@ import {typeInfo} from "../dependency-container";
  *
  * @return {Function} The class decorator
  */
-function injectable<T>(): (target: constructor<T>) => void {
+function injectable<T>(options?: {
+  token?: InjectionToken<T> | InjectionToken<T>[];
+}): (target: constructor<T>) => void {
   return function(target: constructor<T>): void {
     typeInfo.set(target, getParamInfo(target));
+
+    if (options && options.token) {
+      if (!Array.isArray(options.token)) {
+        globalContainer.register(options.token, target);
+      } else {
+        options.token.forEach(token => {
+          globalContainer.register(token, target);
+        });
+      }
+    }
   };
 }
 


### PR DESCRIPTION
This would solve:

https://github.com/microsoft/tsyringe/pull/115

Passing a simple argument to `@injectable()`, would allow the additional registrations of tokens for this current class. Allowing someone to tag their interfaces directly from the decorator and having them be resolved right away.

@Xapphire13 Any thoughts?
