### PR TITLE
Supports passing a default provider in the `inject` decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,35 @@ class Foo {
 }
 ```
 
+#### Default Provider
+By default, if a dependency is not marked as optional (see above), a provider must exist for this dependency. However, you can use `{ defaultProvider: Provider<any> }` to specify a default provider for this dependency. This provider will be used if no other provider is registered for this dependency.
+
+If you pass both a `defaultProvider` and `isOptional:true`, the `defaultProvider` will be used, making `isOptional: true` useless. 
+
+```typescript
+import {injectable, inject} from "tsyringe";
+
+class Database {}
+
+@injectable()
+class Foo {
+  constructor(@inject("Database", { defaultProvider: { useValue: new Database() } }) private database: Database) {}
+}
+```
+
+All types of providers are supported. Here's an example using a factory:
+
+```typescript
+import {injectable, inject} from "tsyringe";
+import dependencyContainer from "./dependency-container";
+
+@injectable()
+class Foo {
+  constructor(@inject("Database", {defaultProvider: {useFactory: (dependencyContainer: DependencyContainer) => { return dependencyContainer.resolve("Database")}}}) private database: Database) {
+  }
+}
+```
+
 ### injectAll()
 
 Parameter decorator for array parameters where the array contents will come from the container.

--- a/src/decorators/inject.ts
+++ b/src/decorators/inject.ts
@@ -1,5 +1,7 @@
 import {defineInjectionTokenMetadata} from "../reflection-helpers";
 import InjectionToken, {TokenDescriptor} from "../providers/injection-token";
+import {Provider} from "../providers";
+import {instance as globalContainer} from "../dependency-container";
 
 /**
  * Parameter decorator factory that allows for interface information to be stored in the constructor's metadata
@@ -8,7 +10,10 @@ import InjectionToken, {TokenDescriptor} from "../providers/injection-token";
  */
 function inject(
   token: InjectionToken<any>,
-  options?: {isOptional?: boolean}
+  options?: {
+    isOptional?: boolean;
+    defaultProvider?: Provider<any>;
+  }
 ): (
   target: any,
   propertyKey: string | symbol | undefined,
@@ -19,6 +24,12 @@ function inject(
     multiple: false,
     isOptional: options && options.isOptional
   };
+
+  if (options && options.defaultProvider) {
+    // @ts-expect-error options.defaultProvider is the right type but this Typescript version doesn't seem to realize that one of the overloads method would accept this type.
+    globalContainer.register(token, options.defaultProvider);
+  }
+
   return defineInjectionTokenMetadata(data);
 }
 


### PR DESCRIPTION
This PR adds the ability to support defining a default provider, directly inside the `@inject` decorator. Passing both a `defaultProvider` and `isOptional:true`, will simply use the `defaultProvider`, making `isOptional: true` useless in this case. We could add a warning or error but I think that doing the right thing, which is to use the default Provider is the right call.

Maybe the best thing we should do is use a conditional type like this, so devs can know that it's one or the other.

```
type InjectOptionsType = {} & (
  | {isOptional?: boolean}
  | {defaultProvider?: Provider<any>});
``` 

I think however we would need to increase the version of TypeScript to support this, which I can do in a future version.

This will resolve: https://github.com/microsoft/tsyringe/pull/163