### PR TITLE
Prevent singletons with container-scoped dependencies 

### DIFF
--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -240,6 +240,13 @@ class InternalDependencyContainer implements DependencyContainer {
 
     this.executePreResolutionInterceptor<T>(token, "Single");
 
+    // Using a container scoped registration within a singleton is not allowed
+    if(registration && registration.options.lifecycle === Lifecycle.ContainerScoped && context.isSingleton) {
+      throw new Error(
+        `Attempted to use a container scoped registration "${token.toString()}" within a singleton`
+      );
+    }
+
     if (registration) {
       const result = this.resolveRegistration(registration, context) as T;
       this.executePostResolutionInterceptor(token, result, "Single");
@@ -313,6 +320,7 @@ class InternalDependencyContainer implements DependencyContainer {
     const isContainerScoped =
       registration.options.lifecycle === Lifecycle.ContainerScoped;
 
+    context.isSingleton = isSingleton;
     const returnInstance = isSingleton || isContainerScoped;
 
     let resolved: T;

--- a/src/resolution-context.ts
+++ b/src/resolution-context.ts
@@ -2,4 +2,5 @@ import {Registration} from "./dependency-container";
 
 export default class ResolutionContext {
   scopedResolutions: Map<Registration, any> = new Map();
+  isSingleton: boolean = false;
 }


### PR DESCRIPTION
... by passing singleton-information within the resolution context and checking it during resolution.

Conceptually, singletons should not use container-scoped dependencies.
I can not think of any use case where the previous behavior (initializing a singleton that uses one specific instance of a container-scoped dependency) would be useful. In fact, it could lead to hard-to-detect bugs by using unexpected instances.

As this _could_ be a breaking change, it might be necessary to have the change only be activated by configuration. Please give me feedback in that regard :) 